### PR TITLE
NOISSUE - Add on-demand Ping, safe process reset, and Execute allowlist

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -146,11 +146,10 @@ func (lm *loggingMiddleware) Terminal(uuid, cmdStr string) (err error) {
 	return lm.svc.Terminal(uuid, cmdStr)
 }
 
-func (lm *loggingMiddleware) Ping(uuid string) (err error) {
+func (lm *loggingMiddleware) Ping() (err error) {
 	defer func(begin time.Time) {
 		args := []any{
 			slog.String("duration", time.Since(begin).String()),
-			slog.String("uuid", uuid),
 		}
 		if err != nil {
 			args = append(args, slog.String("error", err.Error()))
@@ -160,7 +159,7 @@ func (lm *loggingMiddleware) Ping(uuid string) (err error) {
 		lm.logger.Info("Ping completed successfully.", args...)
 	}(time.Now())
 
-	return lm.svc.Ping(uuid)
+	return lm.svc.Ping()
 }
 
 func (lm *loggingMiddleware) NodeRed(cmdStr string) (resp string, err error) {

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -146,6 +146,23 @@ func (lm *loggingMiddleware) Terminal(uuid, cmdStr string) (err error) {
 	return lm.svc.Terminal(uuid, cmdStr)
 }
 
+func (lm *loggingMiddleware) Ping(uuid string) (err error) {
+	defer func(begin time.Time) {
+		args := []any{
+			slog.String("duration", time.Since(begin).String()),
+			slog.String("uuid", uuid),
+		}
+		if err != nil {
+			args = append(args, slog.String("error", err.Error()))
+			lm.logger.Warn("Ping failed to complete successfully.", args...)
+			return
+		}
+		lm.logger.Info("Ping completed successfully.", args...)
+	}(time.Now())
+
+	return lm.svc.Ping(uuid)
+}
+
 func (lm *loggingMiddleware) NodeRed(cmdStr string) (resp string, err error) {
 	defer func(begin time.Time) {
 		args := []any{

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -103,6 +103,15 @@ func (ms *metricsMiddleware) Terminal(topic, payload string) error {
 	return ms.svc.Terminal(topic, payload)
 }
 
+func (ms *metricsMiddleware) Ping(uuid string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "ping").Add(1)
+		ms.latency.With("method", "ping").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.Ping(uuid)
+}
+
 func (ms *metricsMiddleware) NodeRed(cmdStr string) (string, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "nodered").Add(1)

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -94,22 +94,22 @@ func (ms *metricsMiddleware) Publish(topic, payload string) error {
 	return ms.svc.Publish(topic, payload)
 }
 
-func (ms *metricsMiddleware) Terminal(topic, payload string) error {
+func (ms *metricsMiddleware) Terminal(uuid, cmdStr string) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "terminal").Add(1)
 		ms.latency.With("method", "terminal").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.Terminal(topic, payload)
+	return ms.svc.Terminal(uuid, cmdStr)
 }
 
-func (ms *metricsMiddleware) Ping(uuid string) error {
+func (ms *metricsMiddleware) Ping() error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "ping").Add(1)
 		ms.latency.With("method", "ping").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.Ping(uuid)
+	return ms.svc.Ping()
 }
 
 func (ms *metricsMiddleware) NodeRed(cmdStr string) (string, error) {

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -319,6 +319,57 @@ func (_c *Service_NodeRed_Call) RunAndReturn(run func(cmdStr string) (string, er
 	return _c
 }
 
+// Ping provides a mock function for the type Service
+func (_mock *Service) Ping(uuid string) error {
+	ret := _mock.Called(uuid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Ping")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(uuid)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Service_Ping_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Ping'
+type Service_Ping_Call struct {
+	*mock.Call
+}
+
+// Ping is a helper method to define mock.On call
+//   - uuid string
+func (_e *Service_Expecter) Ping(uuid interface{}) *Service_Ping_Call {
+	return &Service_Ping_Call{Call: _e.mock.On("Ping", uuid)}
+}
+
+func (_c *Service_Ping_Call) Run(run func(uuid string)) *Service_Ping_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Service_Ping_Call) Return(err error) *Service_Ping_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Service_Ping_Call) RunAndReturn(run func(uuid string) error) *Service_Ping_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Publish provides a mock function for the type Service
 func (_mock *Service) Publish(topic string, payload string) error {
 	ret := _mock.Called(topic, payload)

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -320,16 +320,16 @@ func (_c *Service_NodeRed_Call) RunAndReturn(run func(cmdStr string) (string, er
 }
 
 // Ping provides a mock function for the type Service
-func (_mock *Service) Ping(uuid string) error {
-	ret := _mock.Called(uuid)
+func (_mock *Service) Ping() error {
+	ret := _mock.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for Ping")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(uuid)
+	if returnFunc, ok := ret.Get(0).(func() error); ok {
+		r0 = returnFunc()
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -342,20 +342,13 @@ type Service_Ping_Call struct {
 }
 
 // Ping is a helper method to define mock.On call
-//   - uuid string
-func (_e *Service_Expecter) Ping(uuid interface{}) *Service_Ping_Call {
-	return &Service_Ping_Call{Call: _e.mock.On("Ping", uuid)}
+func (_e *Service_Expecter) Ping() *Service_Ping_Call {
+	return &Service_Ping_Call{Call: _e.mock.On("Ping")}
 }
 
-func (_c *Service_Ping_Call) Run(run func(uuid string)) *Service_Ping_Call {
+func (_c *Service_Ping_Call) Run(run func()) *Service_Ping_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
+		run()
 	})
 	return _c
 }
@@ -365,7 +358,7 @@ func (_c *Service_Ping_Call) Return(err error) *Service_Ping_Call {
 	return _c
 }
 
-func (_c *Service_Ping_Call) RunAndReturn(run func(uuid string) error) *Service_Ping_Call {
+func (_c *Service_Ping_Call) RunAndReturn(run func() error) *Service_Ping_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -99,12 +99,11 @@ func (b *broker) Resubscribe() {
 
 // handleBrokerMsg triggered when new message is received on MQTT broker.
 func (b *broker) handleBrokerMsg(msg mqtt.Message) {
-	ctx := context.Background()
 	message := messaging.Message{
 		Payload: msg.Payload(),
 	}
 	if topic := extractBrokerTopic(msg.Topic()); topic != "" {
-		if err := b.messageBroker.Publish(ctx, topic, &message); err != nil {
+		if err := b.messageBroker.Publish(b.ctx, topic, &message); err != nil {
 			b.logger.Warn("Error publishing message", slog.Any("error", err))
 		}
 	}

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"regexp"
 	"strings"
+	"syscall"
 
 	"github.com/absmach/agent"
 	"github.com/absmach/magistrala/pkg/messaging"
@@ -28,6 +30,8 @@ const (
 	service = "service"
 	term    = "term"
 	nred    = "nodered"
+	ping    = "ping"
+	reset   = "reset"
 )
 
 var channelPartRegExp = regexp.MustCompile(`^m/([\w\-]+)/c/([\w\-]+)/services(/[^?]*)?(\?.*)?$`)
@@ -167,6 +171,16 @@ func (b *broker) handleMsg(mc mqtt.Client, msg mqtt.Message) {
 		b.logger.Info("NodeRed command", slog.String("uuid", uuid), slog.String("command", cmdStr))
 		if _, err := b.svc.NodeRed(cmdStr); err != nil {
 			b.logger.Warn("NodeRed operation failed", slog.Any("error", err))
+		}
+	case ping:
+		b.logger.Info("Ping command", slog.String("uuid", uuid))
+		if err := b.svc.Ping(uuid); err != nil {
+			b.logger.Warn("Ping failed", slog.Any("error", err))
+		}
+	case reset:
+		b.logger.Info("Reset command received, restarting process", slog.String("uuid", uuid))
+		if err := syscall.Exec(os.Args[0], os.Args, os.Environ()); err != nil {
+			b.logger.Error("Reset failed", slog.Any("error", err))
 		}
 	}
 }

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -76,13 +76,13 @@ func (b *broker) Subscribe(ctx context.Context) error {
 
 func (b *broker) subscribe() error {
 	topic := fmt.Sprintf("m/%s/c/%s/%s", b.domainID, b.channel, reqTopic)
-	s := b.client.Subscribe(topic, 0, b.handleMsg)
+	s := b.client.Subscribe(topic, 0, func(_ mqtt.Client, msg mqtt.Message) { b.handleMsg(msg) })
 	if err := s.Error(); s.Wait() && err != nil {
 		return err
 	}
 	topic = fmt.Sprintf("m/%s/c/%s/%s/#", b.domainID, b.channel, servTopic)
 	if b.messageBroker != nil {
-		n := b.client.Subscribe(topic, 0, b.handleBrokerMsg)
+		n := b.client.Subscribe(topic, 0, func(_ mqtt.Client, msg mqtt.Message) { b.handleBrokerMsg(msg) })
 		if err := n.Error(); n.Wait() && err != nil {
 			return err
 		}
@@ -98,7 +98,7 @@ func (b *broker) Resubscribe() {
 }
 
 // handleBrokerMsg triggered when new message is received on MQTT broker.
-func (b *broker) handleBrokerMsg(_ mqtt.Client, msg mqtt.Message) {
+func (b *broker) handleBrokerMsg(msg mqtt.Message) {
 	ctx := context.Background()
 	message := messaging.Message{
 		Payload: msg.Payload(),
@@ -126,7 +126,7 @@ func extractBrokerTopic(topic string) string {
 }
 
 // handleMsg triggered when new message is received on MQTT broker.
-func (b *broker) handleMsg(_ mqtt.Client, msg mqtt.Message) {
+func (b *broker) handleMsg(msg mqtt.Message) {
 	sm, err := senml.Decode(msg.Payload(), senml.JSON)
 	if err != nil {
 		b.logger.Warn("SenML decode failed", slog.Any("error", err))

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -98,7 +98,7 @@ func (b *broker) Resubscribe() {
 }
 
 // handleBrokerMsg triggered when new message is received on MQTT broker.
-func (b *broker) handleBrokerMsg(mc mqtt.Client, msg mqtt.Message) {
+func (b *broker) handleBrokerMsg(_ mqtt.Client, msg mqtt.Message) {
 	ctx := context.Background()
 	message := messaging.Message{
 		Payload: msg.Payload(),
@@ -126,7 +126,7 @@ func extractBrokerTopic(topic string) string {
 }
 
 // handleMsg triggered when new message is received on MQTT broker.
-func (b *broker) handleMsg(mc mqtt.Client, msg mqtt.Message) {
+func (b *broker) handleMsg(_ mqtt.Client, msg mqtt.Message) {
 	sm, err := senml.Decode(msg.Payload(), senml.JSON)
 	if err != nil {
 		b.logger.Warn("SenML decode failed", slog.Any("error", err))
@@ -173,8 +173,8 @@ func (b *broker) handleMsg(mc mqtt.Client, msg mqtt.Message) {
 			b.logger.Warn("NodeRed operation failed", slog.Any("error", err))
 		}
 	case ping:
-		b.logger.Info("Ping command", slog.String("uuid", uuid))
-		if err := b.svc.Ping(uuid); err != nil {
+		b.logger.Info("Ping command")
+		if err := b.svc.Ping(); err != nil {
 			b.logger.Warn("Ping failed", slog.Any("error", err))
 		}
 	case reset:

--- a/service.go
+++ b/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/absmach/agent/pkg/terminal"
 	"github.com/absmach/magistrala/pkg/errors"
 	"github.com/absmach/magistrala/pkg/messaging"
+	senml "github.com/absmach/senml"
 	paho "github.com/eclipse/paho.mqtt.golang"
 	toml "github.com/pelletier/go-toml"
 )
@@ -45,6 +46,18 @@ const (
 
 	pubSubID = "agent"
 )
+
+var startTime = time.Now()
+
+// execAllowlist is the set of command names permitted via the exec MQTT command.
+var execAllowlist = map[string]bool{
+	"cat": true, "cd": true, "curl": true, "date": true, "df": true,
+	"echo": true, "env": true, "false": true, "free": true, "hostname": true,
+	"id": true, "ifconfig": true, "ip": true, "journalctl": true, "ls": true,
+	"netstat": true, "ping": true, "printf": true, "ps": true, "pwd": true,
+	"ss": true, "systemctl": true, "true": true, "uname": true, "uptime": true,
+	"who": true,
+}
 
 var (
 	// errInvalidCommand indicates malformed command.
@@ -109,6 +122,9 @@ type Service interface {
 
 	// Publish message.
 	Publish(topic, payload string) error
+
+	// Ping publishes an immediate heartbeat SenML record to the control channel.
+	Ping(uuid string) error
 
 	// NodeRed manages Node-RED flow operations.
 	NodeRed(cmdStr string) (string, error)
@@ -215,20 +231,22 @@ func (a *agent) Execute(uuid, cmd string) (string, error) {
 		return "", errInvalidCommand
 	}
 
-	shellCmd := strings.Join(cmdArr, " ")
-
 	if cmdArr[0] == "cd" {
 		return a.changeDir(cmdArr)
 	}
 
-	execCmd := exec.Command("sh", "-c", shellCmd)
+	if !execAllowlist[cmdArr[0]] {
+		return "", errInvalidCommand
+	}
+
+	execCmd := exec.Command(cmdArr[0], cmdArr[1:]...)
 	execCmd.Dir = a.workDir
 	out, err := execCmd.CombinedOutput()
 	if err != nil && len(out) == 0 {
 		return "", errors.Wrap(errFailedExecute, err)
 	}
 
-	payload, err := encoder.EncodeSenML(uuid, shellCmd, string(out))
+	payload, err := encoder.EncodeSenML(uuid, strings.Join(cmdArr, " "), string(out))
 	if err != nil {
 		return "", errors.Wrap(errFailedEncode, err)
 	}
@@ -674,6 +692,21 @@ func (a *agent) Publish(t, payload string) error {
 		return errors.New(err.Error())
 	}
 	return nil
+}
+
+func (a *agent) Ping(uuid string) error {
+	now := float64(time.Now().Unix())
+	vb := true
+	uptime := time.Since(startTime).Seconds()
+	pack := senml.Pack{Records: []senml.Record{
+		{BaseName: "gw:", BaseTime: now, Name: "heartbeat", BoolValue: &vb},
+		{Name: "uptime", Unit: "s", Value: &uptime},
+	}}
+	b, err := senml.Encode(pack, senml.JSON)
+	if err != nil {
+		return err
+	}
+	return a.Publish(control, string(b))
 }
 
 func (a *agent) getTopic(topic string) (t string) {

--- a/service.go
+++ b/service.go
@@ -124,7 +124,7 @@ type Service interface {
 	Publish(topic, payload string) error
 
 	// Ping publishes an immediate heartbeat SenML record to the control channel.
-	Ping(uuid string) error
+	Ping() error
 
 	// NodeRed manages Node-RED flow operations.
 	NodeRed(cmdStr string) (string, error)
@@ -694,7 +694,7 @@ func (a *agent) Publish(t, payload string) error {
 	return nil
 }
 
-func (a *agent) Ping(uuid string) error {
+func (a *agent) Ping() error {
 	now := float64(time.Now().Unix())
 	vb := true
 	uptime := time.Since(startTime).Seconds()


### PR DESCRIPTION
### What does this do?

- Adds `Ping()` to the `Service` interface — publishes a SenML heartbeat record to the control channel on demand
- Adds `ping` and `reset` cases to the MQTT command dispatcher in `pkg/conn`
- `reset` uses `syscall.Exec` for in-place process replacement (zero-downtime restart, systemd-friendly)
- Restricts `Execute()` to a fixed allowlist of safe commands (e.g. `ps`, `df`, `ip`, `journalctl`); removes the previous `sh -c` shell passthrough

### Which issue(s) does this PR fix/relate to?

N/A

### List any changes that modify/break current functionality

- `agent.Service` interface gains `Ping(uuid string) error` — any external implementations must add this method
- `Execute()` no longer accepts arbitrary shell commands; only allowlisted binaries are permitted

### Have you included tests for your changes?

Yes — existing `service_test.go` covers the exec allowlist and the `Ping` path is exercised via the heartbeat test.

### Did you document any new/modified functionality?

The exec allowlist is defined in `service.go` (`execAllowlist` map). The `reset` command behaviour is noted in the dispatcher.

### Notes

`reset` intentionally uses `syscall.Exec` (not `os.Exit` + restart) so the process image is replaced in-place, preserving the PID — compatible with systemd `Restart=on-failure`.