### PR TITLE
AGT-26 - Add persistent config store with MQTT get/set

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -429,7 +429,7 @@ func initLogger(levelText string) (*slog.Logger, *slog.LevelVar, error) {
 	return slog.New(logHandler), &levelVar, nil
 }
 
-func applyPersistedOverrides(cfg agent.Config, store *pkgconfig.Store) agent.Config {
+func applyPersistedOverrides(cfg agent.Config, store pkgconfig.Store) agent.Config {
 	for key, val := range store.All() {
 		agent.ApplyConfigEntry(&cfg, key, val)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -116,6 +116,13 @@ func main() {
 		return
 	}
 	cfg = applyPersistedOverrides(cfg, store)
+	// Sync the live log-level variable with any persisted log_level override.
+	if val, ok := store.Get("log_level"); ok {
+		var l slog.Level
+		if err := l.UnmarshalText([]byte(val)); err == nil {
+			levelVar.Set(l)
+		}
+	}
 
 	if err := validateRuntimeConfig(cfg); err != nil {
 		logger.Error("Failed to validate config", slog.Any("error", err))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/absmach/agent/api"
 	"github.com/absmach/agent/middleware"
 	"github.com/absmach/agent/pkg/bootstrap"
+	pkgconfig "github.com/absmach/agent/pkg/config"
 	"github.com/absmach/agent/pkg/conn"
 	"github.com/absmach/agent/pkg/devicemgr"
 	"github.com/absmach/agent/pkg/iface"
@@ -59,6 +60,7 @@ type config struct {
 	BootstrapRetryDelay  string `env:"MG_AGENT_BOOTSTRAP_RETRY_DELAY_SECONDS" envDefault:"10"`
 	BootstrapSkipTLS     string `env:"MG_AGENT_BOOTSTRAP_SKIP_TLS" envDefault:"false"`
 	DeviceDBPath         string `env:"MG_AGENT_DEVICE_DB_PATH" envDefault:"/var/lib/agent/devices.db"`
+	ConfigPath           string `env:"MG_AGENT_CONFIG_PATH" envDefault:"agent-config.json"`
 }
 
 var (
@@ -107,6 +109,14 @@ func main() {
 		}
 	}
 
+	store, err := pkgconfig.NewStore(c.ConfigPath)
+	if err != nil {
+		logger.Error("Failed to open persistent config store", slog.Any("error", err))
+		exitCode = 1
+		return
+	}
+	cfg = applyPersistedOverrides(cfg, store)
+
 	if err := validateRuntimeConfig(cfg); err != nil {
 		logger.Error("Failed to validate config", slog.Any("error", err))
 		exitCode = 1
@@ -140,7 +150,7 @@ func main() {
 	}
 	defer devices.Close()
 
-	svc, err := agent.New(ctx, mqttClient, &cfg, noderedClient, logger, devices)
+	svc, err := agent.New(ctx, mqttClient, &cfg, noderedClient, logger, devices, store)
 	if err != nil {
 		logger.Error("Error in agent service", slog.Any("error", err))
 		exitCode = 1
@@ -415,6 +425,13 @@ func initLogger(levelText string) (*slog.Logger, error) {
 	})
 
 	return slog.New(logHandler), nil
+}
+
+func applyPersistedOverrides(cfg agent.Config, store *pkgconfig.Store) agent.Config {
+	for key, val := range store.All() {
+		agent.ApplyConfigEntry(&cfg, key, val)
+	}
+	return cfg
 }
 
 func loadBootConfig(c agent.Config, cfg config, logger *slog.Logger) (agent.Config, error) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -91,7 +91,7 @@ func main() {
 		return
 	}
 
-	logger, err := initLogger(cfg.Log.Level)
+	logger, levelVar, err := initLogger(cfg.Log.Level)
 	if err != nil {
 		log.Printf("Failed to create logger: %s", err)
 		exitCode = 1
@@ -150,7 +150,7 @@ func main() {
 	}
 	defer devices.Close()
 
-	svc, err := agent.New(ctx, mqttClient, &cfg, noderedClient, logger, devices, store)
+	svc, err := agent.New(ctx, mqttClient, &cfg, noderedClient, logger, devices, store, levelVar)
 	if err != nil {
 		logger.Error("Error in agent service", slog.Any("error", err))
 		exitCode = 1
@@ -414,17 +414,19 @@ func StopSignalHandler(ctx context.Context, cancel context.CancelFunc, logger *s
 	}
 }
 
-func initLogger(levelText string) (*slog.Logger, error) {
+func initLogger(levelText string) (*slog.Logger, *slog.LevelVar, error) {
 	var level slog.Level
 	if err := level.UnmarshalText([]byte(levelText)); err != nil {
-		return &slog.Logger{}, fmt.Errorf(`{"level":"error","message":"%s: %s","ts":"%s"}`, err, levelText, time.Now())
+		return &slog.Logger{}, nil, fmt.Errorf(`{"level":"error","message":"%s: %s","ts":"%s"}`, err, levelText, time.Now())
 	}
 
+	var levelVar slog.LevelVar
+	levelVar.Set(level)
 	logHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: level,
+		Level: &levelVar,
 	})
 
-	return slog.New(logHandler), nil
+	return slog.New(logHandler), &levelVar, nil
 }
 
 func applyPersistedOverrides(cfg agent.Config, store *pkgconfig.Store) agent.Config {

--- a/docker/.env
+++ b/docker/.env
@@ -36,3 +36,6 @@ MG_AGENT_BOOTSTRAP_SKIP_TLS=false
 
 ## Device Manager
 MG_AGENT_DEVICE_DB_PATH=/var/lib/agent/devices.db
+
+## Config Store
+MG_AGENT_CONFIG_PATH=/var/lib/agent/agent-config.json

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       MG_AGENT_OTA_BINARY_PATH: ${MG_AGENT_OTA_BINARY_PATH}
       MG_AGENT_OTA_DOWNLOAD_DIR: ${MG_AGENT_OTA_DOWNLOAD_DIR}
       MG_AGENT_DEVICE_DB_PATH: ${MG_AGENT_DEVICE_DB_PATH}
+      MG_AGENT_CONFIG_PATH: ${MG_AGENT_CONFIG_PATH}
     volumes:
       - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
       - agent-data:/var/lib/agent  # agent process must have write access to persist device DB

--- a/export_test.go
+++ b/export_test.go
@@ -44,6 +44,7 @@ func TerminalCloseExistingSessionForTest(uuid string) (int, error) {
 	ag := &agent{
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 		terminals: map[string]terminal.Session{uuid: nil},
+		config:    &Config{},
 	}
 
 	cmd := base64.StdEncoding.EncodeToString([]byte(close))

--- a/export_test.go
+++ b/export_test.go
@@ -13,6 +13,10 @@ import (
 
 const NodeRedTLSConfigIDForTest = nodeRedTLSConfigID
 
+func ApplyConfigEntryForTest(cfg *Config, key, val string) {
+	ApplyConfigEntry(cfg, key, val)
+}
+
 func ChangeDirForTest(workDir string, cmd []string) (string, string, error) {
 	ag := &agent{workDir: workDir}
 	output, err := ag.changeDir(cmd)

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -1,0 +1,80 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+// Store is a thread-safe, file-backed key-value store that persists entries
+// to a JSON file immediately on every Set call.
+type Store struct {
+	mu      sync.RWMutex
+	entries map[string]string
+	path    string
+}
+
+// NewStore opens (or creates) the JSON file at path and loads any existing
+// entries into memory. Returns an error only if the file exists but cannot
+// be parsed; a missing file is treated as an empty store.
+func NewStore(path string) (*Store, error) {
+	s := &Store{
+		entries: make(map[string]string),
+		path:    path,
+	}
+	if err := s.load(); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Get returns the value for key and whether it was found.
+func (s *Store) Get(key string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.entries[key]
+	return v, ok
+}
+
+// Set writes the key/value pair to the in-memory cache and flushes the full
+// store to disk before returning.
+func (s *Store) Set(key, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[key] = value
+	return s.persist()
+}
+
+// All returns a snapshot of all entries.
+func (s *Store) All() map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]string, len(s.entries))
+	for k, v := range s.entries {
+		out[k] = v
+	}
+	return out
+}
+
+func (s *Store) load() error {
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, &s.entries)
+}
+
+func (s *Store) persist() error {
+	b, err := json.MarshalIndent(s.entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"encoding/json"
+	"maps"
 	"os"
 	"sync"
 )
@@ -39,24 +40,33 @@ func (s *Store) Get(key string) (string, bool) {
 	return v, ok
 }
 
-// Set writes the key/value pair to the in-memory cache and flushes the full
-// store to disk before returning.
+// Set writes key→value to the in-memory cache and immediately persists.
+// If the disk write fails the in-memory change is rolled back.
 func (s *Store) Set(key, value string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	prev, existed := s.entries[key]
 	s.entries[key] = value
-	return s.persist()
+	snapshot := s.copyEntries()
+	s.mu.Unlock()
+
+	if err := s.writeSnapshot(snapshot); err != nil {
+		s.mu.Lock()
+		if existed {
+			s.entries[key] = prev
+		} else {
+			delete(s.entries, key)
+		}
+		s.mu.Unlock()
+		return err
+	}
+	return nil
 }
 
 // All returns a snapshot of all entries.
 func (s *Store) All() map[string]string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	out := make(map[string]string, len(s.entries))
-	for k, v := range s.entries {
-		out[k] = v
-	}
-	return out
+	return s.copyEntries()
 }
 
 func (s *Store) load() error {
@@ -64,11 +74,21 @@ func (s *Store) load() error {
 	if err != nil {
 		return err
 	}
+	if len(b) == 0 {
+		return nil
+	}
 	return json.Unmarshal(b, &s.entries)
 }
 
-func (s *Store) persist() error {
-	b, err := json.MarshalIndent(s.entries, "", "  ")
+// copyEntries returns a copy of s.entries. Must be called with the lock held.
+func (s *Store) copyEntries() map[string]string {
+	out := make(map[string]string, len(s.entries))
+	maps.Copy(out, s.entries)
+	return out
+}
+
+func (s *Store) writeSnapshot(m map[string]string) error {
+	b, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"maps"
 	"os"
 	"sync"
@@ -32,7 +33,7 @@ func NewStore(path string) (Store, error) {
 		entries: make(map[string]string),
 		path:    path,
 	}
-	if err := s.load(); err != nil && !os.IsNotExist(err) {
+	if err := s.load(); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
 	return s, nil
@@ -48,21 +49,19 @@ func (s *fileStore) Get(key string) (string, bool) {
 
 // Set writes key→value to the in-memory cache and immediately persists.
 // If the disk write fails the in-memory change is rolled back.
+// The lock is held for the duration of the disk write to prevent concurrent
+// writers from racing on the same snapshot file.
 func (s *fileStore) Set(key, value string) error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	prev, existed := s.entries[key]
 	s.entries[key] = value
-	snapshot := s.copyEntries()
-	s.mu.Unlock()
-
-	if err := s.writeSnapshot(snapshot); err != nil {
-		s.mu.Lock()
+	if err := s.writeSnapshot(s.copyEntries()); err != nil {
 		if existed {
 			s.entries[key] = prev
 		} else {
 			delete(s.entries, key)
 		}
-		s.mu.Unlock()
 		return err
 	}
 	return nil
@@ -70,21 +69,18 @@ func (s *fileStore) Set(key, value string) error {
 
 // Remove deletes key from the store and persists immediately.
 // It is a no-op if the key does not exist.
+// The lock is held for the duration of the disk write to prevent concurrent
+// writers from racing on the same snapshot file.
 func (s *fileStore) Remove(key string) error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	prev, existed := s.entries[key]
 	if !existed {
-		s.mu.Unlock()
 		return nil
 	}
 	delete(s.entries, key)
-	snapshot := s.copyEntries()
-	s.mu.Unlock()
-
-	if err := s.writeSnapshot(snapshot); err != nil {
-		s.mu.Lock()
+	if err := s.writeSnapshot(s.copyEntries()); err != nil {
 		s.entries[key] = prev
-		s.mu.Unlock()
 		return err
 	}
 	return nil

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -10,9 +10,15 @@ import (
 	"sync"
 )
 
-// Store is a thread-safe, file-backed key-value store that persists entries
-// to a JSON file immediately on every Set call.
-type Store struct {
+// Store is the interface for a thread-safe, file-backed key-value store.
+type Store interface {
+	Get(key string) (string, bool)
+	Set(key, value string) error
+	Remove(key string) error
+	All() map[string]string
+}
+
+type fileStore struct {
 	mu      sync.RWMutex
 	entries map[string]string
 	path    string
@@ -21,8 +27,8 @@ type Store struct {
 // NewStore opens (or creates) the JSON file at path and loads any existing
 // entries into memory. Returns an error only if the file exists but cannot
 // be parsed; a missing file is treated as an empty store.
-func NewStore(path string) (*Store, error) {
-	s := &Store{
+func NewStore(path string) (Store, error) {
+	s := &fileStore{
 		entries: make(map[string]string),
 		path:    path,
 	}
@@ -33,7 +39,7 @@ func NewStore(path string) (*Store, error) {
 }
 
 // Get returns the value for key and whether it was found.
-func (s *Store) Get(key string) (string, bool) {
+func (s *fileStore) Get(key string) (string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	v, ok := s.entries[key]
@@ -42,7 +48,7 @@ func (s *Store) Get(key string) (string, bool) {
 
 // Set writes key→value to the in-memory cache and immediately persists.
 // If the disk write fails the in-memory change is rolled back.
-func (s *Store) Set(key, value string) error {
+func (s *fileStore) Set(key, value string) error {
 	s.mu.Lock()
 	prev, existed := s.entries[key]
 	s.entries[key] = value
@@ -62,14 +68,36 @@ func (s *Store) Set(key, value string) error {
 	return nil
 }
 
+// Remove deletes key from the store and persists immediately.
+// It is a no-op if the key does not exist.
+func (s *fileStore) Remove(key string) error {
+	s.mu.Lock()
+	prev, existed := s.entries[key]
+	if !existed {
+		s.mu.Unlock()
+		return nil
+	}
+	delete(s.entries, key)
+	snapshot := s.copyEntries()
+	s.mu.Unlock()
+
+	if err := s.writeSnapshot(snapshot); err != nil {
+		s.mu.Lock()
+		s.entries[key] = prev
+		s.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
 // All returns a snapshot of all entries.
-func (s *Store) All() map[string]string {
+func (s *fileStore) All() map[string]string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.copyEntries()
 }
 
-func (s *Store) load() error {
+func (s *fileStore) load() error {
 	b, err := os.ReadFile(s.path)
 	if err != nil {
 		return err
@@ -81,13 +109,13 @@ func (s *Store) load() error {
 }
 
 // copyEntries returns a copy of s.entries. Must be called with the lock held.
-func (s *Store) copyEntries() map[string]string {
+func (s *fileStore) copyEntries() map[string]string {
 	out := make(map[string]string, len(s.entries))
 	maps.Copy(out, s.entries)
 	return out
 }
 
-func (s *Store) writeSnapshot(m map[string]string) error {
+func (s *fileStore) writeSnapshot(m map[string]string) error {
 	b, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return err

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/absmach/agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_MissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	s, err := config.NewStore(path)
+	require.NoError(t, err)
+	_, ok := s.Get("any")
+	assert.False(t, ok, "expected empty store when file is missing")
+}
+
+func TestNewStore_MalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	err := os.WriteFile(path, []byte("not-valid-json"), 0o600)
+	require.NoError(t, err)
+	_, err = config.NewStore(path)
+	assert.Error(t, err, "expected error on malformed JSON")
+}
+
+func TestNewStore_EmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	err := os.WriteFile(path, []byte(""), 0o600)
+	require.NoError(t, err)
+	_, err = config.NewStore(path)
+	assert.Error(t, err, "expected error on empty file")
+}
+
+func TestStore_SetGet_RoundTrip(t *testing.T) {
+	s, err := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	require.NoError(t, err)
+	require.NoError(t, s.Set("key", "value"))
+	val, ok := s.Get("key")
+	assert.True(t, ok)
+	assert.Equal(t, "value", val)
+}
+
+func TestStore_GetMissingKey(t *testing.T) {
+	s, err := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	require.NoError(t, err)
+	_, ok := s.Get("missing")
+	assert.False(t, ok)
+}
+
+func TestStore_Set_Overwrites(t *testing.T) {
+	s, err := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	require.NoError(t, err)
+	require.NoError(t, s.Set("key", "first"))
+	require.NoError(t, s.Set("key", "second"))
+	val, ok := s.Get("key")
+	assert.True(t, ok)
+	assert.Equal(t, "second", val)
+}
+
+func TestStore_Persistence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	s1, err := config.NewStore(path)
+	require.NoError(t, err)
+	require.NoError(t, s1.Set("key", "persisted"))
+
+	s2, err := config.NewStore(path)
+	require.NoError(t, err)
+	val, ok := s2.Get("key")
+	assert.True(t, ok, "expected key to survive store reload")
+	assert.Equal(t, "persisted", val)
+}
+
+func TestStore_All_Snapshot(t *testing.T) {
+	s, err := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	require.NoError(t, err)
+	require.NoError(t, s.Set("a", "1"))
+	require.NoError(t, s.Set("b", "2"))
+
+	all := s.All()
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, all)
+
+	// Mutating the snapshot must not affect the store.
+	all["c"] = "3"
+	_, ok := s.Get("c")
+	assert.False(t, ok, "snapshot mutation must not affect the store")
+}
+
+func TestStore_Set_WriteError(t *testing.T) {
+	// Path in a non-existent subdirectory — NewStore succeeds (file not found),
+	// but persist() fails because the parent directory doesn't exist.
+	path := filepath.Join(t.TempDir(), "noexist", "config.json")
+	s, err := config.NewStore(path)
+	require.NoError(t, err)
+	err = s.Set("key", "val")
+	assert.Error(t, err, "expected error when parent directory does not exist")
+}

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -139,4 +139,6 @@ func TestStore_Set_WriteError(t *testing.T) {
 	require.NoError(t, err)
 	err = s.Set("key", "val")
 	assert.Error(t, err, "expected error when parent directory does not exist")
+	_, ok := s.Get("key")
+	assert.False(t, ok, "in-memory entry must be rolled back after write error")
 }

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -93,6 +93,44 @@ func TestStore_All_Snapshot(t *testing.T) {
 	assert.False(t, ok, "snapshot mutation must not affect the store")
 }
 
+func TestStore_Remove_ExistingKey(t *testing.T) {
+	s, err := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	require.NoError(t, err)
+	require.NoError(t, s.Set("key", "value"))
+	require.NoError(t, s.Remove("key"))
+	_, ok := s.Get("key")
+	assert.False(t, ok, "expected key to be removed")
+}
+
+func TestStore_Remove_MissingKey(t *testing.T) {
+	s, err := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	require.NoError(t, err)
+	assert.NoError(t, s.Remove("nonexistent"), "remove of missing key must not error")
+}
+
+func TestStore_Remove_Persists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	s1, err := config.NewStore(path)
+	require.NoError(t, err)
+	require.NoError(t, s1.Set("key", "value"))
+	require.NoError(t, s1.Remove("key"))
+
+	s2, err := config.NewStore(path)
+	require.NoError(t, err)
+	_, ok := s2.Get("key")
+	assert.False(t, ok, "removed key must not reappear after reload")
+}
+
+func TestStore_Remove_WriteError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "noexist", "config.json")
+	s, err := config.NewStore(path)
+	require.NoError(t, err)
+	// Manually seed an entry so Remove actually tries to write.
+	require.Error(t, s.Set("key", "val"), "expected write error")
+	// Remove on a missing-key store is a no-op — no write attempted.
+	assert.NoError(t, s.Remove("key"))
+}
+
 func TestStore_Set_WriteError(t *testing.T) {
 	// Path in a non-existent subdirectory — NewStore succeeds (file not found),
 	// but persist() fails because the parent directory doesn't exist.

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -33,8 +33,10 @@ func TestNewStore_EmptyFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	err := os.WriteFile(path, []byte(""), 0o600)
 	require.NoError(t, err)
-	_, err = config.NewStore(path)
-	assert.Error(t, err, "expected error on empty file")
+	s, err := config.NewStore(path)
+	require.NoError(t, err, "empty file should be treated as an empty store")
+	_, ok := s.Get("any")
+	assert.False(t, ok)
 }
 
 func TestStore_SetGet_RoundTrip(t *testing.T) {

--- a/pkg/ota/ota.go
+++ b/pkg/ota/ota.go
@@ -160,7 +160,7 @@ func download(ctx context.Context, url, dir string, size uint64, pctFn func(floa
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("server returned HTTP %d", resp.StatusCode)
@@ -180,21 +180,21 @@ func download(ctx context.Context, url, dir string, size uint64, pctFn func(floa
 
 	for {
 		if ctx.Err() != nil {
-			f.Close()
-			os.Remove(tmpName)
+			_ = f.Close()
+			_ = os.Remove(tmpName)
 			return "", ctx.Err()
 		}
 		n, rerr := resp.Body.Read(buf)
 		if n > 0 {
 			if _, werr := f.Write(buf[:n]); werr != nil {
-				f.Close()
-				os.Remove(tmpName)
+				_ = f.Close()
+				_ = os.Remove(tmpName)
 				return "", werr
 			}
 			written += int64(n)
 			if size > 0 && uint64(written) > size {
-				f.Close()
-				os.Remove(tmpName)
+				_ = f.Close()
+				_ = os.Remove(tmpName)
 				return "", fmt.Errorf("download exceeded expected size %d bytes", size)
 			}
 			if total > 0 {
@@ -209,13 +209,13 @@ func download(ctx context.Context, url, dir string, size uint64, pctFn func(floa
 			break
 		}
 		if rerr != nil {
-			f.Close()
-			os.Remove(tmpName)
+			_ = f.Close()
+			_ = os.Remove(tmpName)
 			return "", rerr
 		}
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return "", err
 	}
 	pctFn(100)
@@ -240,7 +240,7 @@ func verify(ctx context.Context, url, tmpPath, sha256hex string) (bool, error) {
 		if err != nil {
 			return false, nil // network error — skip
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return false, nil // no sidecar — skip
 		}
@@ -255,7 +255,7 @@ func verify(ctx context.Context, url, tmpPath, sha256hex string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return false, err
@@ -287,27 +287,27 @@ func replace(src, dst string) error {
 
 	in, err := os.Open(src)
 	if err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		return err
 	}
 	if _, err := io.Copy(tmp, in); err != nil {
-		in.Close()
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = in.Close()
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		return err
 	}
-	in.Close()
+	_ = in.Close()
 	if err := tmp.Chmod(0o755); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		return err
 	}
-	tmp.Close()
+	_ = tmp.Close()
 	if err := os.Rename(tmpName, dst); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return err
 	}
-	os.Remove(src)
+	_ = os.Remove(src)
 	return nil
 }

--- a/pkg/ota/ota_test.go
+++ b/pkg/ota/ota_test.go
@@ -143,7 +143,7 @@ func TestDownload_Success(t *testing.T) {
 		progressCalls = append(progressCalls, pct)
 	})
 	require.NoError(t, err)
-	defer os.Remove(path)
+	defer func() { _ = os.Remove(path) }()
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -223,7 +223,7 @@ func TestDownload_ProgressReportedEvery5Percent(t *testing.T) {
 		calls = append(calls, pct)
 	})
 	require.NoError(t, err)
-	os.Remove(path)
+	_ = os.Remove(path)
 
 	// consecutive reported values should differ by at least 5%, except the final 100%
 	for i := 1; i < len(calls)-1; i++ {
@@ -265,7 +265,7 @@ func TestVerify_Sidecar_Match(t *testing.T) {
 	path := writeTempFile(t, content)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "%s  agent.bin\n", sha256hex(content))
+		_, _ = fmt.Fprintf(w, "%s  agent.bin\n", sha256hex(content))
 	}))
 	defer srv.Close()
 
@@ -277,7 +277,7 @@ func TestVerify_Sidecar_Mismatch(t *testing.T) {
 	path := writeTempFile(t, []byte("agent binary"))
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "deadbeef  agent.bin\n")
+		_, _ = fmt.Fprintf(w, "deadbeef  agent.bin\n")
 	}))
 	defer srv.Close()
 
@@ -312,7 +312,7 @@ func TestVerify_InlineTakesPrecedenceOverSidecar(t *testing.T) {
 
 	// sidecar serves wrong hash — inline hash is correct, should pass
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "deadbeef  agent.bin\n")
+		_, _ = fmt.Fprintf(w, "deadbeef  agent.bin\n")
 	}))
 	defer srv.Close()
 

--- a/service.go
+++ b/service.go
@@ -47,6 +47,12 @@ const (
 	data    = "data"
 
 	export = "export"
+
+	keyLogLevel               = "log_level"
+	keyHeartbeatInterval      = "heartbeat_interval"
+	keyTerminalSessionTimeout = "terminal_session_timeout"
+
+	notConfigured = "not_configured"
 )
 
 var startTime = time.Now()
@@ -309,7 +315,7 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 			return errInvalidCommand
 		}
 		if a.store == nil {
-			resp = "not_configured"
+			resp = notConfigured
 		} else if val, ok := a.store.Get(cmdArgs[1]); ok {
 			resp = val
 		} else {
@@ -329,7 +335,7 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 			return err
 		}
 		if a.store == nil {
-			resp = "not_configured"
+			resp = notConfigured
 		} else {
 			if err := a.store.Set(key, val); err != nil {
 				return err
@@ -349,7 +355,7 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 			return errInvalidCommand
 		}
 		if a.store == nil {
-			resp = "not_configured"
+			resp = notConfigured
 		} else {
 			if err := a.store.Remove(key); err != nil {
 				return err
@@ -848,25 +854,25 @@ func (a *agent) Shutdown() {
 // get/set. Only these keys are accepted; unknown keys are rejected to prevent
 // arbitrary storage growth.
 var settableKeys = map[string]bool{
-	"log_level":                true,
-	"heartbeat_interval":       true,
-	"terminal_session_timeout": true,
+	keyLogLevel:               true,
+	keyHeartbeatInterval:      true,
+	keyTerminalSessionTimeout: true,
 }
 
 // validateSettableValue returns errInvalidCommand if val is not a valid value for key.
 func validateSettableValue(key, val string) error {
 	switch key {
-	case "log_level":
+	case keyLogLevel:
 		var l slog.Level
 		if err := l.UnmarshalText([]byte(val)); err != nil {
 			return errInvalidCommand
 		}
-	case "heartbeat_interval":
+	case keyHeartbeatInterval:
 		d, err := time.ParseDuration(val)
 		if err != nil || d < time.Second {
 			return errInvalidCommand
 		}
-	case "terminal_session_timeout":
+	case keyTerminalSessionTimeout:
 		d, err := time.ParseDuration(val)
 		if err != nil || d <= 0 {
 			return errInvalidCommand
@@ -881,13 +887,13 @@ func (a *agent) revertToStartup(key string) {
 	a.cfgMu.Lock()
 	var liveVal string
 	switch key {
-	case "log_level":
+	case keyLogLevel:
 		a.config.Log.Level = a.startupConfig.Log.Level
 		liveVal = a.config.Log.Level
-	case "heartbeat_interval":
+	case keyHeartbeatInterval:
 		a.config.Heartbeat.Interval = a.startupConfig.Heartbeat.Interval
 		liveVal = a.config.Heartbeat.Interval.String()
-	case "terminal_session_timeout":
+	case keyTerminalSessionTimeout:
 		a.config.Terminal.SessionTimeout = a.startupConfig.Terminal.SessionTimeout
 		liveVal = a.config.Terminal.SessionTimeout.String()
 	}
@@ -901,13 +907,13 @@ func (a *agent) revertToStartup(key string) {
 // Used at startup to replay persisted overrides before the agent starts.
 func ApplyConfigEntry(cfg *Config, key, val string) {
 	switch key {
-	case "log_level":
+	case keyLogLevel:
 		cfg.Log.Level = val
-	case "heartbeat_interval":
+	case keyHeartbeatInterval:
 		if d, err := time.ParseDuration(val); err == nil && d > 0 {
 			cfg.Heartbeat.Interval = d
 		}
-	case "terminal_session_timeout":
+	case keyTerminalSessionTimeout:
 		if d, err := time.ParseDuration(val); err == nil && d > 0 {
 			cfg.Terminal.SessionTimeout = d
 		}
@@ -918,14 +924,14 @@ func ApplyConfigEntry(cfg *Config, key, val string) {
 // effect is immediate without requiring a restart.
 func (a *agent) applyLiveUpdate(key, val string) {
 	switch key {
-	case "log_level":
+	case keyLogLevel:
 		if a.logLevel != nil {
 			var l slog.Level
 			if err := l.UnmarshalText([]byte(val)); err == nil {
 				a.logLevel.Set(l)
 			}
 		}
-	case "heartbeat_interval":
+	case keyHeartbeatInterval:
 		if d, err := time.ParseDuration(val); err == nil && d > 0 {
 			select {
 			case a.heartbeatIntervalCh <- d:

--- a/service.go
+++ b/service.go
@@ -159,13 +159,13 @@ type agent struct {
 	devices             *devicemgr.Manager
 	workDir             string
 	otaBusy             atomic.Bool
-	store               *cfgstore.Store
+	store               cfgstore.Store
 	heartbeatIntervalCh chan time.Duration
 	logLevel            *slog.LevelVar
 }
 
 // New returns agent service implementation.
-func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, logger *slog.Logger, devices *devicemgr.Manager, store *cfgstore.Store, levelVar *slog.LevelVar) (Service, error) {
+func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, logger *slog.Logger, devices *devicemgr.Manager, store cfgstore.Store, levelVar *slog.LevelVar) (Service, error) {
 	ag := &agent{
 		mqttClient:          mc,
 		noderedClient:       nc,
@@ -329,6 +329,22 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 			}
 			ApplyConfigEntry(a.config, key, val)
 			a.applyLiveUpdate(key, val)
+			resp = "ok"
+		}
+	case "reset":
+		if len(cmdArgs) < 2 || cmdArgs[1] == "" {
+			return errInvalidCommand
+		}
+		key := cmdArgs[1]
+		if !settableKeys[key] {
+			return errInvalidCommand
+		}
+		if a.store == nil {
+			resp = "not_configured"
+		} else {
+			if err := a.store.Remove(key); err != nil {
+				return err
+			}
 			resp = "ok"
 		}
 	default:

--- a/service.go
+++ b/service.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -162,6 +163,8 @@ type agent struct {
 	store               cfgstore.Store
 	heartbeatIntervalCh chan time.Duration
 	logLevel            *slog.LevelVar
+	cfgMu               sync.RWMutex
+	startupConfig       Config
 }
 
 // New returns agent service implementation.
@@ -178,6 +181,7 @@ func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, lo
 		store:               store,
 		heartbeatIntervalCh: make(chan time.Duration, 1),
 		logLevel:            levelVar,
+		startupConfig:       *cfg,
 	}
 
 	topic := fmt.Sprintf("m/%s/c/%s/gateway/heartbeat",
@@ -321,13 +325,18 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 		if !settableKeys[key] {
 			return errInvalidCommand
 		}
+		if err := validateSettableValue(key, val); err != nil {
+			return err
+		}
 		if a.store == nil {
 			resp = "not_configured"
 		} else {
 			if err := a.store.Set(key, val); err != nil {
 				return err
 			}
+			a.cfgMu.Lock()
 			ApplyConfigEntry(a.config, key, val)
+			a.cfgMu.Unlock()
 			a.applyLiveUpdate(key, val)
 			resp = "ok"
 		}
@@ -345,6 +354,7 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 			if err := a.store.Remove(key); err != nil {
 				return err
 			}
+			a.revertToStartup(key)
 			resp = "ok"
 		}
 	default:
@@ -368,13 +378,14 @@ func (a *agent) Terminal(uuid, cmdStr string) error {
 	if len(cmdArgs) > 1 {
 		ch = cmdArgs[1]
 	}
+	cfg := a.Config()
 	switch cmd {
 	case char:
 		if err := a.terminalWrite(uuid, ch); err != nil {
 			return err
 		}
 	case open:
-		if err := a.terminalOpen(uuid, a.config.Terminal.SessionTimeout); err != nil {
+		if err := a.terminalOpen(uuid, cfg.Terminal.SessionTimeout); err != nil {
 			return err
 		}
 	case close:
@@ -412,7 +423,7 @@ func (a *agent) terminalClose(uuid string) error {
 }
 
 func (a *agent) terminalWrite(uuid, cmd string) error {
-	if err := a.terminalOpen(uuid, a.config.Terminal.SessionTimeout); err != nil {
+	if err := a.terminalOpen(uuid, a.Config().Terminal.SessionTimeout); err != nil {
 		return err
 	}
 	term := a.terminals[uuid]
@@ -475,8 +486,9 @@ func (a *agent) normalizeNodeRedFlow(flowJSON string) string {
 		return flowJSON
 	}
 
-	host, port, useTLS := nodeRedMQTTEndpoint(a.config.MQTT.URL)
-	dataChannel := a.config.Channels.DataChan()
+	cfg := a.Config()
+	host, port, useTLS := nodeRedMQTTEndpoint(cfg.MQTT.URL)
+	dataChannel := cfg.Channels.DataChan()
 	brokerIDs := map[string]struct{}{}
 
 	patchNodeRedValue(payload, func(node map[string]any) {
@@ -491,25 +503,25 @@ func (a *agent) normalizeNodeRedFlow(flowJSON string) string {
 				node["broker"] = host
 			}
 			node["port"] = port
-			node["clientid"] = a.config.MQTT.Username + "-nr"
+			node["clientid"] = cfg.MQTT.Username + "-nr"
 			node["usetls"] = useTLS
-			if useTLS && a.config.MQTT.SkipTLSVer {
+			if useTLS && cfg.MQTT.SkipTLSVer {
 				node["tls"] = nodeRedTLSConfigID
 			} else {
 				delete(node, "tls")
 			}
 			node["credentials"] = map[string]any{
-				"user":     a.config.MQTT.Username,
-				"password": a.config.MQTT.Password,
+				"user":     cfg.MQTT.Username,
+				"password": cfg.MQTT.Password,
 			}
 		case "function":
 			if fn, ok := node["func"].(string); ok {
-				node["func"] = patchNodeRedTopic(fn, a.config.DomainID, dataChannel)
+				node["func"] = patchNodeRedTopic(fn, cfg.DomainID, dataChannel)
 			}
 		}
 
 		if topic, ok := node["topic"].(string); ok {
-			node["topic"] = patchNodeRedTopic(topic, a.config.DomainID, dataChannel)
+			node["topic"] = patchNodeRedTopic(topic, cfg.DomainID, dataChannel)
 		}
 	})
 
@@ -530,7 +542,7 @@ func (a *agent) normalizeNodeRedFlow(flowJSON string) string {
 		})
 	}
 
-	if useTLS && a.config.MQTT.SkipTLSVer {
+	if useTLS && cfg.MQTT.SkipTLSVer {
 		payload = ensureNodeRedTLSConfig(payload)
 	}
 
@@ -687,11 +699,15 @@ func saveExportConfig(fileName string, content []byte) error {
 }
 
 func (a *agent) AddConfig(c Config) error {
+	a.cfgMu.Lock()
+	defer a.cfgMu.Unlock()
 	*a.config = c
 	return nil
 }
 
 func (a *agent) Config() Config {
+	a.cfgMu.RLock()
+	defer a.cfgMu.RUnlock()
 	return *a.config
 }
 
@@ -711,7 +727,7 @@ func (a *agent) Services() []Info {
 
 func (a *agent) Publish(t, payload string) error {
 	topic := a.getTopic(t)
-	mqtt := a.config.MQTT
+	mqtt := a.Config().MQTT
 	token := a.mqttClient.Publish(topic, mqtt.QoS, mqtt.Retain, payload)
 	token.Wait()
 	err := token.Error()
@@ -756,7 +772,7 @@ func (a *agent) selfHeartbeat(ctx context.Context, topic string, interval time.D
 
 func (a *agent) UpdateLiveness(svcname, svctype string) error {
 	if _, ok := a.svcs[svcname]; !ok {
-		svc := NewHeartbeat(svcname, svctype, a.config.Heartbeat.Interval)
+		svc := NewHeartbeat(svcname, svctype, a.Config().Heartbeat.Interval)
 		a.svcs[svcname] = svc
 	}
 	a.svcs[svcname].Update()
@@ -837,6 +853,50 @@ var settableKeys = map[string]bool{
 	"terminal_session_timeout": true,
 }
 
+// validateSettableValue returns errInvalidCommand if val is not a valid value for key.
+func validateSettableValue(key, val string) error {
+	switch key {
+	case "log_level":
+		var l slog.Level
+		if err := l.UnmarshalText([]byte(val)); err != nil {
+			return errInvalidCommand
+		}
+	case "heartbeat_interval":
+		d, err := time.ParseDuration(val)
+		if err != nil || d < time.Second {
+			return errInvalidCommand
+		}
+	case "terminal_session_timeout":
+		d, err := time.ParseDuration(val)
+		if err != nil || d <= 0 {
+			return errInvalidCommand
+		}
+	}
+	return nil
+}
+
+// revertToStartup restores key's value from startupConfig and applies the
+// live update so running subsystems reflect the reverted value immediately.
+func (a *agent) revertToStartup(key string) {
+	a.cfgMu.Lock()
+	var liveVal string
+	switch key {
+	case "log_level":
+		a.config.Log.Level = a.startupConfig.Log.Level
+		liveVal = a.config.Log.Level
+	case "heartbeat_interval":
+		a.config.Heartbeat.Interval = a.startupConfig.Heartbeat.Interval
+		liveVal = a.config.Heartbeat.Interval.String()
+	case "terminal_session_timeout":
+		a.config.Terminal.SessionTimeout = a.startupConfig.Terminal.SessionTimeout
+		liveVal = a.config.Terminal.SessionTimeout.String()
+	}
+	a.cfgMu.Unlock()
+	if liveVal != "" {
+		a.applyLiveUpdate(key, liveVal)
+	}
+}
+
 // ApplyConfigEntry updates cfg in place for the known settable keys.
 // Used at startup to replay persisted overrides before the agent starts.
 func ApplyConfigEntry(cfg *Config, key, val string) {
@@ -876,14 +936,15 @@ func (a *agent) applyLiveUpdate(key, val string) {
 }
 
 func (a *agent) getTopic(topic string) (t string) {
-	domainID := a.config.DomainID
+	cfg := a.Config()
+	domainID := cfg.DomainID
 	switch topic {
 	case control:
-		t = fmt.Sprintf("m/%s/c/%s/res", domainID, a.config.Channels.CtrlChan())
+		t = fmt.Sprintf("m/%s/c/%s/res", domainID, cfg.Channels.CtrlChan())
 	case data:
 		t = fmt.Sprintf("m/%s/c/%s/gateway/telemetry", domainID, a.config.Channels.DataChan())
 	default:
-		t = fmt.Sprintf("m/%s/c/%s/res/%s", domainID, a.config.Channels.CtrlChan(), topic)
+		t = fmt.Sprintf("m/%s/c/%s/res/%s", domainID, cfg.Channels.CtrlChan(), topic)
 	}
 	return t
 }

--- a/service.go
+++ b/service.go
@@ -150,30 +150,34 @@ type Service interface {
 var _ Service = (*agent)(nil)
 
 type agent struct {
-	mqttClient    paho.Client
-	config        *Config
-	noderedClient nodered.Client
-	logger        *slog.Logger
-	svcs          map[string]Heartbeat
-	terminals     map[string]terminal.Session
-	devices       *devicemgr.Manager
-	workDir       string
-	otaBusy       atomic.Bool
-	store         *cfgstore.Store
+	mqttClient          paho.Client
+	config              *Config
+	noderedClient       nodered.Client
+	logger              *slog.Logger
+	svcs                map[string]Heartbeat
+	terminals           map[string]terminal.Session
+	devices             *devicemgr.Manager
+	workDir             string
+	otaBusy             atomic.Bool
+	store               *cfgstore.Store
+	heartbeatIntervalCh chan time.Duration
+	logLevel            *slog.LevelVar
 }
 
 // New returns agent service implementation.
-func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, logger *slog.Logger, devices *devicemgr.Manager, store *cfgstore.Store) (Service, error) {
+func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, logger *slog.Logger, devices *devicemgr.Manager, store *cfgstore.Store, levelVar *slog.LevelVar) (Service, error) {
 	ag := &agent{
-		mqttClient:    mc,
-		noderedClient: nc,
-		config:        cfg,
-		logger:        logger,
-		svcs:          make(map[string]Heartbeat),
-		terminals:     make(map[string]terminal.Session),
-		devices:       devices,
-		workDir:       "/",
-		store:         store,
+		mqttClient:          mc,
+		noderedClient:       nc,
+		config:              cfg,
+		logger:              logger,
+		svcs:                make(map[string]Heartbeat),
+		terminals:           make(map[string]terminal.Session),
+		devices:             devices,
+		workDir:             "/",
+		store:               store,
+		heartbeatIntervalCh: make(chan time.Duration, 1),
+		logLevel:            levelVar,
 	}
 
 	topic := fmt.Sprintf("m/%s/c/%s/gateway/heartbeat",
@@ -297,7 +301,7 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 		if len(cmdArgs) < 2 || cmdArgs[1] == "" {
 			return errInvalidCommand
 		}
-		if !SettableKeys[cmdArgs[1]] {
+		if !settableKeys[cmdArgs[1]] {
 			return errInvalidCommand
 		}
 		if a.store == nil {
@@ -308,11 +312,13 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 			resp = "not_found"
 		}
 	case "set":
-		if len(cmdArgs) < 3 || cmdArgs[1] == "" || cmdArgs[2] == "" {
+		// Use SplitN(3) so values containing commas (e.g. URLs) are preserved.
+		setArgs := strings.SplitN(strings.ReplaceAll(cmdStr, " ", ""), ",", 3)
+		if len(setArgs) < 3 || setArgs[1] == "" || setArgs[2] == "" {
 			return errInvalidCommand
 		}
-		key, val := cmdArgs[1], cmdArgs[2]
-		if !SettableKeys[key] {
+		key, val := setArgs[1], setArgs[2]
+		if !settableKeys[key] {
 			return errInvalidCommand
 		}
 		if a.store == nil {
@@ -322,8 +328,11 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 				return err
 			}
 			ApplyConfigEntry(a.config, key, val)
+			a.applyLiveUpdate(key, val)
 			resp = "ok"
 		}
+	default:
+		return errInvalidCommand
 	}
 	return a.processResponse(uuid, cmd, resp)
 }
@@ -721,6 +730,8 @@ func (a *agent) selfHeartbeat(ctx context.Context, topic string, interval time.D
 		select {
 		case <-ticker.C:
 			publish()
+		case d := <-a.heartbeatIntervalCh:
+			ticker.Reset(d)
 		case <-ctx.Done():
 			return
 		}
@@ -801,34 +812,50 @@ func (a *agent) Shutdown() {
 	a.logger.Info("graceful shutdown complete")
 }
 
-// SettableKeys is the allowlist of config keys that can be read and written
-// via MQTT get/set commands. Only keys in this set are accepted; unknown keys
-// are rejected to prevent arbitrary storage growth and SSRF via nodered_url.
-var SettableKeys = map[string]bool{
+// settableKeys is the allowlist of config keys readable/writable via MQTT
+// get/set. Only these keys are accepted; unknown keys are rejected to prevent
+// arbitrary storage growth.
+var settableKeys = map[string]bool{
 	"log_level":                true,
 	"heartbeat_interval":       true,
 	"terminal_session_timeout": true,
-	"nodered_url":              true,
-	"server_port":              true,
 }
 
 // ApplyConfigEntry updates cfg in place for the known settable keys.
+// Used at startup to replay persisted overrides before the agent starts.
 func ApplyConfigEntry(cfg *Config, key, val string) {
 	switch key {
 	case "log_level":
 		cfg.Log.Level = val
 	case "heartbeat_interval":
-		if d, err := time.ParseDuration(val); err == nil {
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
 			cfg.Heartbeat.Interval = d
 		}
 	case "terminal_session_timeout":
-		if d, err := time.ParseDuration(val); err == nil {
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
 			cfg.Terminal.SessionTimeout = d
 		}
-	case "nodered_url":
-		cfg.NodeRed.URL = val
-	case "server_port":
-		cfg.Server.Port = val
+	}
+}
+
+// applyLiveUpdate propagates a config change to running subsystems so the
+// effect is immediate without requiring a restart.
+func (a *agent) applyLiveUpdate(key, val string) {
+	switch key {
+	case "log_level":
+		if a.logLevel != nil {
+			var l slog.Level
+			if err := l.UnmarshalText([]byte(val)); err == nil {
+				a.logLevel.Set(l)
+			}
+		}
+	case "heartbeat_interval":
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+			select {
+			case a.heartbeatIntervalCh <- d:
+			default:
+			}
+		}
 	}
 }
 

--- a/service.go
+++ b/service.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	cfgstore "github.com/absmach/agent/pkg/config"
 	"github.com/absmach/agent/pkg/devicemgr"
 	"github.com/absmach/agent/pkg/encoder"
 	"github.com/absmach/agent/pkg/iface"
@@ -158,10 +159,11 @@ type agent struct {
 	devices       *devicemgr.Manager
 	workDir       string
 	otaBusy       atomic.Bool
+	store         *cfgstore.Store
 }
 
 // New returns agent service implementation.
-func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, logger *slog.Logger, devices *devicemgr.Manager) (Service, error) {
+func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, logger *slog.Logger, devices *devicemgr.Manager, store *cfgstore.Store) (Service, error) {
 	ag := &agent{
 		mqttClient:    mc,
 		noderedClient: nc,
@@ -171,6 +173,7 @@ func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, lo
 		terminals:     make(map[string]terminal.Session),
 		devices:       devices,
 		workDir:       "/",
+		store:         store,
 	}
 
 	topic := fmt.Sprintf("m/%s/c/%s/gateway/heartbeat",
@@ -289,6 +292,37 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 		fileCont := cmdArgs[3]
 		if err := a.saveConfig(ctx, service, fileName, fileCont); err != nil {
 			return err
+		}
+	case "get":
+		if len(cmdArgs) < 2 || cmdArgs[1] == "" {
+			return errInvalidCommand
+		}
+		if !SettableKeys[cmdArgs[1]] {
+			return errInvalidCommand
+		}
+		if a.store == nil {
+			resp = "not_configured"
+		} else if val, ok := a.store.Get(cmdArgs[1]); ok {
+			resp = val
+		} else {
+			resp = "not_found"
+		}
+	case "set":
+		if len(cmdArgs) < 3 || cmdArgs[1] == "" || cmdArgs[2] == "" {
+			return errInvalidCommand
+		}
+		key, val := cmdArgs[1], cmdArgs[2]
+		if !SettableKeys[key] {
+			return errInvalidCommand
+		}
+		if a.store == nil {
+			resp = "not_configured"
+		} else {
+			if err := a.store.Set(key, val); err != nil {
+				return err
+			}
+			ApplyConfigEntry(a.config, key, val)
+			resp = "ok"
 		}
 	}
 	return a.processResponse(uuid, cmd, resp)
@@ -765,6 +799,37 @@ func (a *agent) Shutdown() {
 	a.logger.Debug("disconnecting MQTT client")
 	a.mqttClient.Disconnect(1000)
 	a.logger.Info("graceful shutdown complete")
+}
+
+// SettableKeys is the allowlist of config keys that can be read and written
+// via MQTT get/set commands. Only keys in this set are accepted; unknown keys
+// are rejected to prevent arbitrary storage growth and SSRF via nodered_url.
+var SettableKeys = map[string]bool{
+	"log_level":                true,
+	"heartbeat_interval":       true,
+	"terminal_session_timeout": true,
+	"nodered_url":              true,
+	"server_port":              true,
+}
+
+// ApplyConfigEntry updates cfg in place for the known settable keys.
+func ApplyConfigEntry(cfg *Config, key, val string) {
+	switch key {
+	case "log_level":
+		cfg.Log.Level = val
+	case "heartbeat_interval":
+		if d, err := time.ParseDuration(val); err == nil {
+			cfg.Heartbeat.Interval = d
+		}
+	case "terminal_session_timeout":
+		if d, err := time.ParseDuration(val); err == nil {
+			cfg.Terminal.SessionTimeout = d
+		}
+	case "nodered_url":
+		cfg.NodeRed.URL = val
+	case "server_port":
+		cfg.Server.Port = val
+	}
 }
 
 func (a *agent) getTopic(topic string) (t string) {

--- a/service.go
+++ b/service.go
@@ -53,6 +53,7 @@ const (
 	keyTerminalSessionTimeout = "terminal_session_timeout"
 
 	notConfigured = "not_configured"
+	notFound      = "not_found"
 )
 
 var startTime = time.Now()
@@ -319,11 +320,15 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 		} else if val, ok := a.store.Get(cmdArgs[1]); ok {
 			resp = val
 		} else {
-			resp = "not_found"
+			resp = notFound
 		}
 	case "set":
 		// Use SplitN(3) so values containing commas (e.g. URLs) are preserved.
-		setArgs := strings.SplitN(strings.ReplaceAll(cmdStr, " ", ""), ",", 3)
+		parts := strings.SplitN(cmdStr, ",", 3)
+		setArgs := make([]string, len(parts))
+		for i, p := range parts {
+			setArgs[i] = strings.TrimSpace(p)
+		}
 		if len(setArgs) < 3 || setArgs[1] == "" || setArgs[2] == "" {
 			return errInvalidCommand
 		}

--- a/service.go
+++ b/service.go
@@ -953,7 +953,7 @@ func (a *agent) getTopic(topic string) (t string) {
 	case control:
 		t = fmt.Sprintf("m/%s/c/%s/res", domainID, cfg.Channels.CtrlChan())
 	case data:
-		t = fmt.Sprintf("m/%s/c/%s/gateway/telemetry", domainID, a.config.Channels.DataChan())
+		t = fmt.Sprintf("m/%s/c/%s/gateway/telemetry", domainID, cfg.Channels.DataChan())
 	default:
 		t = fmt.Sprintf("m/%s/c/%s/res/%s", domainID, cfg.Channels.CtrlChan(), topic)
 	}

--- a/service.go
+++ b/service.go
@@ -285,7 +285,11 @@ func (a *agent) Control(uuid, cmdStr string) error {
 //	b, _ := toml.Marshal(cfg)
 //	config_file_content := base64.StdEncoding.EncodeToString(b).
 func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
-	cmdArgs := strings.Split(strings.ReplaceAll(cmdStr, " ", ""), ",")
+	rawParts := strings.Split(cmdStr, ",")
+	cmdArgs := make([]string, len(rawParts))
+	for i, p := range rawParts {
+		cmdArgs[i] = strings.TrimSpace(p)
+	}
 	if len(cmdArgs) < 1 {
 		return errInvalidCommand
 	}
@@ -323,16 +327,10 @@ func (a *agent) ServiceConfig(ctx context.Context, uuid, cmdStr string) error {
 			resp = notFound
 		}
 	case "set":
-		// Use SplitN(3) so values containing commas (e.g. URLs) are preserved.
-		parts := strings.SplitN(cmdStr, ",", 3)
-		setArgs := make([]string, len(parts))
-		for i, p := range parts {
-			setArgs[i] = strings.TrimSpace(p)
-		}
-		if len(setArgs) < 3 || setArgs[1] == "" || setArgs[2] == "" {
+		if len(cmdArgs) < 3 || cmdArgs[1] == "" || cmdArgs[2] == "" {
 			return errInvalidCommand
 		}
-		key, val := setArgs[1], setArgs[2]
+		key, val := cmdArgs[1], cmdArgs[2]
 		if !settableKeys[key] {
 			return errInvalidCommand
 		}
@@ -882,6 +880,8 @@ func validateSettableValue(key, val string) error {
 		if err != nil || d <= 0 {
 			return errInvalidCommand
 		}
+	default:
+		return errInvalidCommand
 	}
 	return nil
 }

--- a/service_test.go
+++ b/service_test.go
@@ -55,7 +55,7 @@ func testConfig() agent.Config {
 	)
 }
 
-func newServiceWithStore(t *testing.T, cfg agent.Config, store *cfgstore.Store) (agent.Service, *agentmocks.MQTTClient, *nrmocks.Client, error) {
+func newServiceWithStore(t *testing.T, cfg agent.Config, store cfgstore.Store) (agent.Service, *agentmocks.MQTTClient, *nrmocks.Client, error) {
 	cfg.DomainID = domainID
 	mqttClient := agentmocks.NewMQTTClient(t)
 	nodeRed := nrmocks.NewClient(t)
@@ -524,11 +524,42 @@ func TestConfigGetSet(t *testing.T) {
 			useStore: true,
 			err:      true,
 		},
+		{
+			desc:     "reset key without store returns not_configured",
+			cmd:      "reset,log_level",
+			useStore: false,
+			wantResp: "not_configured",
+		},
+		{
+			desc:     "reset existing key returns ok",
+			cmd:      "reset,log_level",
+			useStore: true,
+			seed:     map[string]string{"log_level": "debug"},
+			wantResp: "ok",
+		},
+		{
+			desc:     "reset missing key is no-op and returns ok",
+			cmd:      "reset,log_level",
+			useStore: true,
+			wantResp: "ok",
+		},
+		{
+			desc:     "reject reset without key",
+			cmd:      "reset",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "reject reset with unknown key",
+			cmd:      "reset,mqtt_password",
+			useStore: true,
+			err:      true,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			var s *cfgstore.Store
+			var s cfgstore.Store
 			if tc.useStore {
 				var storeErr error
 				s, storeErr = cfgstore.NewStore(filepath.Join(t.TempDir(), "config.json"))
@@ -553,6 +584,64 @@ func TestConfigGetSet(t *testing.T) {
 			} else {
 				assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %v", tc.desc, err))
 			}
+		})
+	}
+}
+
+func TestApplyConfigEntry(t *testing.T) {
+	cases := []struct {
+		desc    string
+		key     string
+		val     string
+		check   func(t *testing.T, cfg agent.Config)
+	}{
+		{
+			desc: "set log level",
+			key:  "log_level",
+			val:  "warn",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, "warn", cfg.Log.Level)
+			},
+		},
+		{
+			desc: "set heartbeat interval",
+			key:  "heartbeat_interval",
+			val:  "30s",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, 30*time.Second, cfg.Heartbeat.Interval)
+			},
+		},
+		{
+			desc: "set terminal session timeout",
+			key:  "terminal_session_timeout",
+			val:  "2m",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, 2*time.Minute, cfg.Terminal.SessionTimeout)
+			},
+		},
+		{
+			desc: "invalid duration is ignored",
+			key:  "heartbeat_interval",
+			val:  "not-a-duration",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, time.Hour, cfg.Heartbeat.Interval)
+			},
+		},
+		{
+			desc: "unknown key is a no-op",
+			key:  "mqtt_password",
+			val:  "secret",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, "client-secret", cfg.MQTT.Password)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			cfg := testConfig()
+			agent.ApplyConfigEntryForTest(&cfg, tc.key, tc.val)
+			tc.check(t, cfg)
 		})
 	}
 }

--- a/service_test.go
+++ b/service_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/absmach/agent"
 	agentmocks "github.com/absmach/agent/mocks"
+	cfgstore "github.com/absmach/agent/pkg/config"
 	"github.com/absmach/agent/pkg/devicemgr"
 	"github.com/absmach/agent/pkg/iface"
 	nrmocks "github.com/absmach/agent/pkg/nodered/mocks"
@@ -54,6 +55,24 @@ func testConfig() agent.Config {
 	)
 }
 
+func newServiceWithStore(t *testing.T, cfg agent.Config, store *cfgstore.Store) (agent.Service, *agentmocks.MQTTClient, *nrmocks.Client, error) {
+	cfg.DomainID = domainID
+	mqttClient := agentmocks.NewMQTTClient(t)
+	nodeRed := nrmocks.NewClient(t)
+
+	hbToken := agentmocks.NewMQTTToken(t)
+	hbToken.On("Wait").Maybe().Return(true)
+	hbToken.On("Error").Maybe().Return(error(nil))
+	mqttClient.On("Publish", mqttTopic("ctrl-channel", "services/agent/heartbeat"),
+		mock.Anything, mock.Anything, mock.Anything).Maybe().Return(hbToken)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, store)
+	return svc, mqttClient, nodeRed, err
+}
+
 func newService(t *testing.T, cfg agent.Config, devices ...*devicemgr.Manager) (agent.Service, *agentmocks.MQTTClient, *nrmocks.Client, error) {
 	t.Helper()
 	cfg.DomainID = domainID
@@ -77,7 +96,7 @@ func newService(t *testing.T, cfg agent.Config, devices ...*devicemgr.Manager) (
 		mgr = devices[0]
 	}
 
-	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), mgr)
+	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), mgr, nil)
 	return svc, mqttClient, nodeRed, err
 }
 
@@ -417,6 +436,121 @@ func TestServiceConfig(t *testing.T) {
 			assert.NoError(t, err)
 			if tc.file != "" {
 				assert.FileExists(t, tc.file)
+			}
+		})
+	}
+}
+
+func TestConfigGetSet(t *testing.T) {
+	cases := []struct {
+		desc     string
+		cmd      string
+		useStore bool
+		seed     map[string]string
+		wantResp string
+		err      bool
+	}{
+		{
+			desc:     "get key without store returns not_configured",
+			cmd:      "get,log_level",
+			useStore: false,
+			wantResp: "not_configured",
+		},
+		{
+			desc:     "get missing key returns not_found",
+			cmd:      "get,log_level",
+			useStore: true,
+			wantResp: "not_found",
+		},
+		{
+			desc:     "set key without store returns not_configured",
+			cmd:      "set,log_level,debug",
+			useStore: false,
+			wantResp: "not_configured",
+		},
+		{
+			desc:     "set key persists and returns ok",
+			cmd:      "set,log_level,debug",
+			useStore: true,
+			wantResp: "ok",
+		},
+		{
+			desc:     "get key after set returns previously set value",
+			cmd:      "get,log_level",
+			useStore: true,
+			seed:     map[string]string{"log_level": "debug"},
+			wantResp: "debug",
+		},
+		{
+			desc:     "set heartbeat_interval stores valid duration",
+			cmd:      "set,heartbeat_interval,30s",
+			useStore: true,
+			wantResp: "ok",
+		},
+		{
+			desc:     "set heartbeat_interval with invalid duration stores but returns ok",
+			cmd:      "set,heartbeat_interval,not-a-duration",
+			useStore: true,
+			wantResp: "ok",
+		},
+		{
+			desc:     "reject get without key",
+			cmd:      "get",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "reject get with empty key",
+			cmd:      "get,",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "reject get with unknown key",
+			cmd:      "get,mqtt_password",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "reject set without value",
+			cmd:      "set,log_level",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "reject set with unknown key",
+			cmd:      "set,mqtt_password,secret",
+			useStore: true,
+			err:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			var s *cfgstore.Store
+			if tc.useStore {
+				var storeErr error
+				s, storeErr = cfgstore.NewStore(filepath.Join(t.TempDir(), "config.json"))
+				assert.Nil(t, storeErr, fmt.Sprintf("%s: unexpected store error %v", tc.desc, storeErr))
+				for k, v := range tc.seed {
+					assert.Nil(t, s.Set(k, v))
+				}
+			}
+			svc, mqttClient, _, setupErr := newServiceWithStore(t, testConfig(), s)
+			assert.Nil(t, setupErr, fmt.Sprintf("%s: unexpected setup error %v", tc.desc, setupErr))
+
+			if !tc.err {
+				expectMQTTPublish(t, mqttClient, mqttTopic("ctrl-channel", "res"), nil).Run(func(args mock.Arguments) {
+					payload, _ := args.Get(3).(string)
+					assert.Contains(t, payload, tc.wantResp, fmt.Sprintf("%s: unexpected response payload", tc.desc))
+				})
+			}
+
+			err := svc.ServiceConfig(context.Background(), "uuid", tc.cmd)
+			if tc.err {
+				assert.Error(t, err, fmt.Sprintf("%s: expected error", tc.desc))
+			} else {
+				assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %v", tc.desc, err))
 			}
 		})
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -69,7 +69,7 @@ func newServiceWithStore(t *testing.T, cfg agent.Config, store *cfgstore.Store) 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, store)
+	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, store, nil)
 	return svc, mqttClient, nodeRed, err
 }
 
@@ -96,7 +96,7 @@ func newService(t *testing.T, cfg agent.Config, devices ...*devicemgr.Manager) (
 		mgr = devices[0]
 	}
 
-	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), mgr, nil)
+	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), mgr, nil, nil)
 	return svc, mqttClient, nodeRed, err
 }
 
@@ -383,8 +383,9 @@ func TestServiceConfig(t *testing.T) {
 			pubErr:      errBoom,
 		},
 		{
-			desc: "publish empty response for unknown config command",
+			desc: "return error for unknown config command",
 			cmd:  "noop",
+			err:  true,
 		},
 		{
 			desc: "reject malformed save command",

--- a/service_test.go
+++ b/service_test.go
@@ -602,10 +602,10 @@ func TestConfigGetSet(t *testing.T) {
 
 func TestApplyConfigEntry(t *testing.T) {
 	cases := []struct {
-		desc    string
-		key     string
-		val     string
-		check   func(t *testing.T, cfg agent.Config)
+		desc  string
+		key   string
+		val   string
+		check func(t *testing.T, cfg agent.Config)
 	}{
 		{
 			desc: "set log level",

--- a/service_test.go
+++ b/service_test.go
@@ -63,7 +63,7 @@ func newServiceWithStore(t *testing.T, cfg agent.Config, store cfgstore.Store) (
 	hbToken := agentmocks.NewMQTTToken(t)
 	hbToken.On("Wait").Maybe().Return(true)
 	hbToken.On("Error").Maybe().Return(error(nil))
-	mqttClient.On("Publish", mqttTopic("ctrl-channel", "services/agent/heartbeat"),
+	mqttClient.On("Publish", mqttTopic("data-channel", "gateway/heartbeat"),
 		mock.Anything, mock.Anything, mock.Anything).Maybe().Return(hbToken)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/service_test.go
+++ b/service_test.go
@@ -489,10 +489,22 @@ func TestConfigGetSet(t *testing.T) {
 			wantResp: "ok",
 		},
 		{
-			desc:     "set heartbeat_interval with invalid duration stores but returns ok",
+			desc:     "reject set with invalid duration",
 			cmd:      "set,heartbeat_interval,not-a-duration",
 			useStore: true,
-			wantResp: "ok",
+			err:      true,
+		},
+		{
+			desc:     "reject set with invalid log level",
+			cmd:      "set,log_level,BOGUS",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "reject set with heartbeat interval below minimum",
+			cmd:      "set,heartbeat_interval,500ms",
+			useStore: true,
+			err:      true,
 		},
 		{
 			desc:     "reject get without key",
@@ -565,7 +577,7 @@ func TestConfigGetSet(t *testing.T) {
 				s, storeErr = cfgstore.NewStore(filepath.Join(t.TempDir(), "config.json"))
 				assert.Nil(t, storeErr, fmt.Sprintf("%s: unexpected store error %v", tc.desc, storeErr))
 				for k, v := range tc.seed {
-					assert.Nil(t, s.Set(k, v))
+					require.NoError(t, s.Set(k, v))
 				}
 			}
 			svc, mqttClient, _, setupErr := newServiceWithStore(t, testConfig(), s)
@@ -623,6 +635,22 @@ func TestApplyConfigEntry(t *testing.T) {
 			desc: "invalid duration is ignored",
 			key:  "heartbeat_interval",
 			val:  "not-a-duration",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, time.Hour, cfg.Heartbeat.Interval)
+			},
+		},
+		{
+			desc: "zero duration is ignored",
+			key:  "heartbeat_interval",
+			val:  "0s",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, time.Hour, cfg.Heartbeat.Interval)
+			},
+		},
+		{
+			desc: "negative duration is ignored",
+			key:  "heartbeat_interval",
+			val:  "-5s",
 			check: func(t *testing.T, cfg agent.Config) {
 				assert.Equal(t, time.Hour, cfg.Heartbeat.Interval)
 			},


### PR DESCRIPTION
### What does this do?

Adds a file-backed persistent config store. Supports MQTT `get`/`set` commands. Live-updates log level and heartbeat interval.

### Which issue(s) does this PR fix/relate to?

Resolves #26

### List any changes that modify/break current functionality

`agent.New()` gains two new parameters: `*config.Store`, `*slog.LevelVar`.

### Have you included tests for your changes?

Yes. Store and service config tests added.

### Did you document any new/modified functionality?

No docs changes needed.

### Notes

Settable keys: `log_level`, `heartbeat_interval`, `terminal_session_timeout`.