### PR TITLE
AG - 28 - Add telemetry configuration and self-telemetry feature

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,6 +50,7 @@ type config struct {
 	MqttCert             string `env:"MG_AGENT_MQTT_CLIENT_CERT"              envDefault:"client.cert"`
 	MqttPrivateKey       string `env:"MG_AGENT_MQTT_CLIENT_KEY"               envDefault:"client.key"`
 	HeartbeatInterval    string `env:"MG_AGENT_HEARTBEAT_INTERVAL"            envDefault:"10s"`
+	TelemetryInterval    string `env:"MG_AGENT_TELEMETRY_INTERVAL"            envDefault:"0s"`
 	TermSessionTimeout   string `env:"MG_AGENT_TERMINAL_SESSION_TIMEOUT"      envDefault:"60s"`
 	OTAEnabled           string `env:"MG_AGENT_OTA_ENABLED"                   envDefault:"false"`
 	OTABinaryPath        string `env:"MG_AGENT_OTA_BINARY_PATH"               envDefault:"/usr/local/bin/agent"`
@@ -284,6 +285,15 @@ func loadEnvConfig(cfg config) (agent.Config, error) {
 	ct := agent.TerminalConfig{
 		SessionTimeout: termSessionTimeout,
 	}
+
+	telemetryInterval, err := time.ParseDuration(cfg.TelemetryInterval)
+	if err != nil {
+		return agent.Config{}, err
+	}
+	tlc := agent.TelemetryConfig{
+		Interval: telemetryInterval,
+	}
+
 	nc := agent.NodeRedConfig{URL: cfg.NodeRedURL}
 	lc := agent.LogConfig{Level: cfg.LogLevel}
 
@@ -334,7 +344,7 @@ func loadEnvConfig(cfg config) (agent.Config, error) {
 		Retain:      retain,
 	}
 
-	c := agent.NewConfig(sc, agent.ChanConfig{}, nc, lc, mc, ch, ct, oc)
+	c := agent.NewConfig(sc, agent.ChanConfig{}, nc, lc, mc, ch, ct, oc, tlc)
 	c.CommandSecret = cfg.CommandSecret
 	return c, nil
 }

--- a/config.go
+++ b/config.go
@@ -69,6 +69,10 @@ type HeartbeatConfig struct {
 	Interval time.Duration
 }
 
+type TelemetryConfig struct {
+	Interval time.Duration `json:"interval"`
+}
+
 type TerminalConfig struct {
 	SessionTimeout time.Duration `json:"session_timeout"`
 }
@@ -92,6 +96,7 @@ type Config struct {
 	Server        ServerConfig    `json:"server"`
 	Terminal      TerminalConfig  `json:"terminal"`
 	Heartbeat     HeartbeatConfig `json:"heartbeat"`
+	Telemetry     TelemetryConfig `json:"telemetry"`
 	Channels      ChanConfig      `json:"channels"`
 	NodeRed       NodeRedConfig   `json:"nodered"`
 	Log           LogConfig       `json:"log"`
@@ -102,7 +107,7 @@ type Config struct {
 	CommandSecret string          `json:"-"`
 }
 
-func NewConfig(sc ServerConfig, cc ChanConfig, nc NodeRedConfig, lc LogConfig, mc MQTTConfig, hc HeartbeatConfig, tc TerminalConfig, oc OTAConfig) Config {
+func NewConfig(sc ServerConfig, cc ChanConfig, nc NodeRedConfig, lc LogConfig, mc MQTTConfig, hc HeartbeatConfig, tc TerminalConfig, oc OTAConfig, tlc TelemetryConfig) Config {
 	return Config{
 		Server:    sc,
 		Channels:  cc,
@@ -112,6 +117,7 @@ func NewConfig(sc ServerConfig, cc ChanConfig, nc NodeRedConfig, lc LogConfig, m
 		Heartbeat: hc,
 		Terminal:  tc,
 		OTA:       oc,
+		Telemetry: tlc,
 	}
 }
 
@@ -158,6 +164,32 @@ func (d *TerminalConfig) UnmarshalJSON(b []byte) error {
 	case string:
 		var err error
 		d.SessionTimeout, err = time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
+}
+
+// UnmarshalJSON parses the duration from JSON.
+func (d *TelemetryConfig) UnmarshalJSON(b []byte) error {
+	var v map[string]any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	interval, ok := v["interval"]
+	if !ok {
+		return errors.New("missing value")
+	}
+	switch value := interval.(type) {
+	case float64:
+		d.Interval = time.Duration(value)
+		return nil
+	case string:
+		var err error
+		d.Interval, err = time.ParseDuration(value)
 		if err != nil {
 			return err
 		}

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -26,6 +26,7 @@ func TestApplyBootstrapResponse(t *testing.T) {
 		agent.HeartbeatConfig{Interval: time.Second},
 		agent.TerminalConfig{SessionTimeout: time.Minute},
 		agent.OTAConfig{},
+		agent.TelemetryConfig{},
 	)
 
 	cases := []struct {

--- a/service.go
+++ b/service.go
@@ -916,7 +916,7 @@ func (a *agent) selfHeartbeatPayload() ([]byte, error) {
 
 func (a *agent) selfTelemetry(ctx context.Context, topic string, interval time.Duration, qos byte) {
 	publish := func() {
-		now := float64(time.Now().UnixNano())
+		now := float64(time.Now().UnixNano()) / float64(time.Second)
 		uptime := time.Since(startTime).Seconds()
 		pack := []senml.Record{
 			{BaseName: "gw:", BaseTime: now, Name: "uptime", Unit: "s", Value: &uptime},
@@ -932,14 +932,45 @@ func (a *agent) selfTelemetry(ctx context.Context, topic string, interval time.D
 			a.logger.Warn("self-telemetry publish failed", slog.Any("error", err))
 		}
 	}
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+
+	var ticker *time.Ticker
+	var tickerCh <-chan time.Time
+
+	stopTicker := func() {
+		if ticker != nil {
+			ticker.Stop()
+			ticker = nil
+			tickerCh = nil
+		}
+	}
+
+	startTicker := func(d time.Duration) {
+		stopTicker()
+		ticker = time.NewTicker(d)
+		tickerCh = ticker.C
+	}
+
+	if interval > 0 {
+		startTicker(interval)
+		publish()
+	}
+	defer stopTicker()
+
 	for {
 		select {
-		case <-ticker.C:
+		case <-tickerCh:
 			publish()
 		case d := <-a.telemetryIntervalCh:
-			ticker.Reset(d)
+			if d > 0 {
+				if ticker == nil {
+					startTicker(d)
+					publish()
+				} else {
+					ticker.Reset(d)
+				}
+			} else {
+				stopTicker()
+			}
 		case <-ctx.Done():
 			return
 		}
@@ -1222,7 +1253,7 @@ func (a *agent) applyLiveUpdate(key, val string) {
 			}
 		}
 	case keyTelemetryInterval:
-		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+		if d, err := time.ParseDuration(val); err == nil {
 			select {
 			case a.telemetryIntervalCh <- d:
 			default:

--- a/service.go
+++ b/service.go
@@ -51,6 +51,7 @@ const (
 
 	keyLogLevel               = "log_level"
 	keyHeartbeatInterval      = "heartbeat_interval"
+	keyTelemetryInterval      = "telemetry_interval"
 	keyTerminalSessionTimeout = "terminal_session_timeout"
 	keyCommandSecret          = "command_secret"
 	keyBsValid                = "bs_valid"
@@ -221,6 +222,7 @@ type agent struct {
 	otaBusy             atomic.Bool
 	store               cfgstore.Store
 	heartbeatIntervalCh chan time.Duration
+	telemetryIntervalCh chan time.Duration
 	logLevel            *slog.LevelVar
 	cfgMu               sync.RWMutex
 	startupConfig       Config
@@ -242,6 +244,7 @@ func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, lo
 		workDir:             "/",
 		store:               store,
 		heartbeatIntervalCh: make(chan time.Duration, 1),
+		telemetryIntervalCh: make(chan time.Duration, 1),
 		logLevel:            levelVar,
 		startupConfig:       *cfg,
 		bootstrapCachePath:  bootstrapCachePath,
@@ -258,6 +261,12 @@ func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, lo
 	topic := fmt.Sprintf("m/%s/c/%s/gateway/heartbeat",
 		cfg.DomainID, cfg.Channels.DataChan())
 	go ag.selfHeartbeat(ctx, topic, cfg.Heartbeat.Interval, cfg.MQTT.QoS)
+
+	if cfg.Telemetry.Interval > 0 {
+		telemetryTopic := fmt.Sprintf("m/%s/c/%s/gateway/telemetry",
+			cfg.DomainID, cfg.Channels.DataChan())
+		go ag.selfTelemetry(ctx, telemetryTopic, cfg.Telemetry.Interval, cfg.MQTT.QoS)
+	}
 
 	return ag, nil
 }
@@ -905,6 +914,38 @@ func (a *agent) selfHeartbeatPayload() ([]byte, error) {
 	return senml.EncodeRecords(pack)
 }
 
+func (a *agent) selfTelemetry(ctx context.Context, topic string, interval time.Duration, qos byte) {
+	publish := func() {
+		now := float64(time.Now().UnixNano())
+		uptime := time.Since(startTime).Seconds()
+		pack := []senml.Record{
+			{BaseName: "gw:", BaseTime: now, Name: "uptime", Unit: "s", Value: &uptime},
+		}
+		b, err := senml.EncodeRecords(pack)
+		if err != nil {
+			a.logger.Warn("failed to encode self-telemetry", slog.Any("error", err))
+			return
+		}
+		token := a.mqttClient.Publish(topic, qos, false, b)
+		token.Wait()
+		if err := token.Error(); err != nil {
+			a.logger.Warn("self-telemetry publish failed", slog.Any("error", err))
+		}
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			publish()
+		case d := <-a.telemetryIntervalCh:
+			ticker.Reset(d)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 func (a *agent) UpdateLiveness(svcname, svctype string) error {
 	a.svcsMu.Lock()
 	defer a.svcsMu.Unlock()
@@ -1060,6 +1101,7 @@ func (a *agent) Shutdown() {
 var settableKeys = map[string]bool{
 	keyLogLevel:               true,
 	keyHeartbeatInterval:      true,
+	keyTelemetryInterval:      true,
 	keyTerminalSessionTimeout: true,
 	keyCommandSecret:          true,
 	keyBsValid:                true,
@@ -1076,6 +1118,11 @@ func validateSettableValue(key, val string) error {
 	case keyHeartbeatInterval:
 		d, err := time.ParseDuration(val)
 		if err != nil || d < time.Second {
+			return errInvalidCommand
+		}
+	case keyTelemetryInterval:
+		d, err := time.ParseDuration(val)
+		if err != nil || d < time.Second || d > time.Hour {
 			return errInvalidCommand
 		}
 	case keyTerminalSessionTimeout:
@@ -1107,6 +1154,9 @@ func (a *agent) revertToStartup(key string) {
 	case keyHeartbeatInterval:
 		a.config.Heartbeat.Interval = a.startupConfig.Heartbeat.Interval
 		liveVal = a.config.Heartbeat.Interval.String()
+	case keyTelemetryInterval:
+		a.config.Telemetry.Interval = a.startupConfig.Telemetry.Interval
+		liveVal = a.config.Telemetry.Interval.String()
 	case keyTerminalSessionTimeout:
 		a.config.Terminal.SessionTimeout = a.startupConfig.Terminal.SessionTimeout
 		liveVal = a.config.Terminal.SessionTimeout.String()
@@ -1129,6 +1179,10 @@ func ApplyConfigEntry(cfg *Config, key, val string) {
 	case keyHeartbeatInterval:
 		if d, err := time.ParseDuration(val); err == nil && d > 0 {
 			cfg.Heartbeat.Interval = d
+		}
+	case keyTelemetryInterval:
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+			cfg.Telemetry.Interval = d
 		}
 	case keyTerminalSessionTimeout:
 		if d, err := time.ParseDuration(val); err == nil && d > 0 {
@@ -1164,6 +1218,13 @@ func (a *agent) applyLiveUpdate(key, val string) {
 		if d, err := time.ParseDuration(val); err == nil && d > 0 {
 			select {
 			case a.heartbeatIntervalCh <- d:
+			default:
+			}
+		}
+	case keyTelemetryInterval:
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+			select {
+			case a.telemetryIntervalCh <- d:
 			default:
 			}
 		}

--- a/service.go
+++ b/service.go
@@ -58,6 +58,8 @@ const (
 
 	notConfigured = "not_configured"
 	notFound      = "not_found"
+
+	senmlNameUptime = "uptime"
 )
 
 var (
@@ -906,7 +908,7 @@ func (a *agent) selfHeartbeatPayload() ([]byte, error) {
 		{BaseName: "agent:", Name: "service_type", StringValue: &svcType},
 		{Name: "heartbeat", BoolValue: &heartbeat},
 		{Name: "fw_version", StringValue: &fwVersion},
-		{Name: "uptime", Unit: "s", Value: &uptime},
+		{Name: senmlNameUptime, Unit: "s", Value: &uptime},
 		{Name: "heap_free", Unit: "By", Value: &heapFreeValue},
 		{Name: "devices", Unit: "count", Value: &deviceCountValue},
 		{Name: "connected", BoolValue: &connected},
@@ -919,7 +921,7 @@ func (a *agent) selfTelemetry(ctx context.Context, topic string, interval time.D
 		now := float64(time.Now().UnixNano()) / float64(time.Second)
 		uptime := time.Since(startTime).Seconds()
 		pack := []senml.Record{
-			{BaseName: "gw:", BaseTime: now, Name: "uptime", Unit: "s", Value: &uptime},
+			{BaseName: "gw:", BaseTime: now, Name: senmlNameUptime, Unit: "s", Value: &uptime},
 		}
 		b, err := senml.EncodeRecords(pack)
 		if err != nil {

--- a/service_test.go
+++ b/service_test.go
@@ -54,6 +54,7 @@ func testConfig() agent.Config {
 		agent.HeartbeatConfig{Interval: time.Hour},
 		agent.TerminalConfig{SessionTimeout: time.Minute},
 		agent.OTAConfig{Enabled: false, BinaryPath: "/usr/local/bin/agent", DownloadDir: "/tmp"},
+		agent.TelemetryConfig{Interval: 0},
 	)
 }
 
@@ -212,43 +213,68 @@ func TestDurationConfigUnmarshalJSON(t *testing.T) {
 		body      string
 		heartbeat time.Duration
 		terminal  time.Duration
+		telemetry time.Duration
 		err       bool
 	}{
 		{
 			desc:      "parse string durations",
-			body:      `{"heartbeat":{"interval":"2s"},"terminal":{"session_timeout":"3s"}}`,
+			body:      `{"heartbeat":{"interval":"2s"},"terminal":{"session_timeout":"3s"},"telemetry":{"interval":"5s"}}`,
 			heartbeat: 2 * time.Second,
 			terminal:  3 * time.Second,
+			telemetry: 5 * time.Second,
 		},
 		{
 			desc:      "parse numeric durations",
-			body:      `{"heartbeat":{"interval":5000000000},"terminal":{"session_timeout":7000000000}}`,
+			body:      `{"heartbeat":{"interval":5000000000},"terminal":{"session_timeout":7000000000},"telemetry":{"interval":10000000000}}`,
 			heartbeat: 5 * time.Second,
 			terminal:  7 * time.Second,
+			telemetry: 10 * time.Second,
+		},
+		{
+			desc:      "parse zero telemetry interval",
+			body:      `{"heartbeat":{"interval":"2s"},"terminal":{"session_timeout":"3s"},"telemetry":{"interval":"0s"}}`,
+			heartbeat: 2 * time.Second,
+			terminal:  3 * time.Second,
+			telemetry: 0,
 		},
 		{
 			desc: "reject missing heartbeat duration",
-			body: `{"heartbeat":{},"terminal":{"session_timeout":"3s"}}`,
+			body: `{"heartbeat":{},"terminal":{"session_timeout":"3s"},"telemetry":{"interval":"5s"}}`,
 			err:  true,
 		},
 		{
 			desc: "reject invalid heartbeat duration",
-			body: `{"heartbeat":{"interval":"soon"},"terminal":{"session_timeout":"3s"}}`,
+			body: `{"heartbeat":{"interval":"soon"},"terminal":{"session_timeout":"3s"},"telemetry":{"interval":"5s"}}`,
 			err:  true,
 		},
 		{
 			desc: "reject invalid heartbeat type",
-			body: `{"heartbeat":{"interval":true},"terminal":{"session_timeout":"3s"}}`,
+			body: `{"heartbeat":{"interval":true},"terminal":{"session_timeout":"3s"},"telemetry":{"interval":"5s"}}`,
 			err:  true,
 		},
 		{
 			desc: "reject missing terminal duration",
-			body: `{"heartbeat":{"interval":"2s"},"terminal":{}}`,
+			body: `{"heartbeat":{"interval":"2s"},"terminal":{},"telemetry":{"interval":"5s"}}`,
 			err:  true,
 		},
 		{
 			desc: "reject invalid terminal duration",
-			body: `{"heartbeat":{"interval":"2s"},"terminal":{"session_timeout":true}}`,
+			body: `{"heartbeat":{"interval":"2s"},"terminal":{"session_timeout":true},"telemetry":{"interval":"5s"}}`,
+			err:  true,
+		},
+		{
+			desc: "reject missing telemetry duration",
+			body: `{"heartbeat":{"interval":"2s"},"terminal":{"session_timeout":"3s"},"telemetry":{}}`,
+			err:  true,
+		},
+		{
+			desc: "reject invalid telemetry duration",
+			body: `{"heartbeat":{"interval":"2s"},"terminal":{"session_timeout":"3s"},"telemetry":{"interval":"soon"}}`,
+			err:  true,
+		},
+		{
+			desc: "reject invalid telemetry type",
+			body: `{"heartbeat":{"interval":"2s"},"terminal":{"session_timeout":"3s"},"telemetry":{"interval":true}}`,
 			err:  true,
 		},
 		{
@@ -269,6 +295,7 @@ func TestDurationConfigUnmarshalJSON(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tc.heartbeat, cfg.Heartbeat.Interval)
 			assert.Equal(t, tc.terminal, cfg.Terminal.SessionTimeout)
+			assert.Equal(t, tc.telemetry, cfg.Telemetry.Interval)
 		})
 	}
 }
@@ -583,6 +610,44 @@ func TestConfigGetSet(t *testing.T) {
 			err:      true,
 		},
 		{
+			desc:     "set telemetry_interval stores valid duration",
+			cmd:      "set,telemetry_interval,30s",
+			useStore: true,
+			wantResp: "ok",
+		},
+		{
+			desc:     "get telemetry_interval after set returns previously set value",
+			cmd:      "get,telemetry_interval",
+			useStore: true,
+			seed:     map[string]string{"telemetry_interval": "30s"},
+			wantResp: "30s",
+		},
+		{
+			desc:     "reject set with invalid telemetry duration",
+			cmd:      "set,telemetry_interval,not-a-duration",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "reject set telemetry interval below minimum",
+			cmd:      "set,telemetry_interval,500ms",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "reject set telemetry interval above maximum",
+			cmd:      "set,telemetry_interval,2h",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "reset telemetry_interval returns ok",
+			cmd:      "reset,telemetry_interval",
+			useStore: true,
+			seed:     map[string]string{"telemetry_interval": "30s"},
+			wantResp: "ok",
+		},
+		{
 			desc:     "reject get without key",
 			cmd:      "get",
 			useStore: true,
@@ -803,6 +868,30 @@ func TestApplyConfigEntry(t *testing.T) {
 			val:  "2m",
 			check: func(t *testing.T, cfg agent.Config) {
 				assert.Equal(t, 2*time.Minute, cfg.Terminal.SessionTimeout)
+			},
+		},
+		{
+			desc: "set telemetry interval",
+			key:  "telemetry_interval",
+			val:  "30s",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, 30*time.Second, cfg.Telemetry.Interval)
+			},
+		},
+		{
+			desc: "invalid telemetry duration is ignored",
+			key:  "telemetry_interval",
+			val:  "not-a-duration",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, time.Duration(0), cfg.Telemetry.Interval)
+			},
+		},
+		{
+			desc: "zero telemetry duration is ignored",
+			key:  "telemetry_interval",
+			val:  "0s",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, time.Duration(0), cfg.Telemetry.Interval)
 			},
 		},
 		{


### PR DESCRIPTION
### What does this do?

Adds configurable `telemetry_interval` via MQTT config commands, mirroring the existing `heartbeat_interval` pattern. When `telemetry_interval` is set to a non-zero value, the agent starts a periodic self-telemetry goroutine that publishes uptime SenML records to `m/<domain>/c/<data_channel>/gateway/telemetry`. The interval can be changed at runtime without restart via `config set telemetry_interval,<duration>` and is persisted to the config store. Range is validated to 1s–1h.

Key changes:

- **`config.go`**: New `TelemetryConfig` struct with `Interval` field and JSON unmarshalling, wired into `Config`.
- **`service.go`**: New `selfTelemetry()` goroutine, `telemetry_interval` in settable keys with validation (1s–1h), live reschedule via `telemetryIntervalCh` channel, and support in `ApplyConfigEntry`/`revertToStartup`/`applyLiveUpdate`.
- **`cmd/main.go`**: New `MG_AGENT_TELEMETRY_INTERVAL` env var (default `0s`, disabled).
- **Tests**: Coverage for get/set/reset, validation, `ApplyConfigEntry`, and JSON unmarshal of telemetry config.

### Which issue(s) does this PR fix/relate to?

Resolves #28

### List any changes that modify/break current functionality

- `NewConfig` signature now requires a `TelemetryConfig` argument. Any callers must be updated.
- Telemetry publishing to `m/<domain>/c/<data_channel>/gateway/telemetry` is now active when `MG_AGENT_TELEMETRY_INTERVAL` is set to a non-zero duration (default is `0s`, so existing deployments are unaffected).

### Have you included tests for your changes?

Yes. Added tests for:

- `telemetry_interval` get/set/reset via MQTT config commands
- Validation: invalid duration, below 1s minimum, above 1h maximum
- `ApplyConfigEntry` for `telemetry_interval` (valid, invalid, zero durations)
- JSON unmarshal of `TelemetryConfig` (string, numeric, zero, missing, invalid)

### Did you document any new/modified functionality?

No documentation files were modified. The new env var `MG_AGENT_TELEMETRY_INTERVAL` and MQTT command `config set telemetry_interval,<duration>` follow existing patterns documented for `heartbeat_interval`.

### Notes

The `heartbeat_interval` live reschedule was already implemented before this PR. This PR extends the same pattern to `telemetry_interval`. The Aeolus agent uses integer seconds (`set,telemetry_interval,10`); this implementation uses Go duration strings (`set,telemetry_interval,10s`) to be consistent with the existing `heartbeat_interval` convention.
