### PR TITLE
AG - 32 - Add disk cache and invalidation for bootstrap responses

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,7 @@ type config struct {
 	BootstrapRetries     string `env:"MG_AGENT_BOOTSTRAP_RETRIES"             envDefault:"5"`
 	BootstrapRetryDelay  string `env:"MG_AGENT_BOOTSTRAP_RETRY_DELAY_SECONDS" envDefault:"10"`
 	BootstrapSkipTLS     string `env:"MG_AGENT_BOOTSTRAP_SKIP_TLS"            envDefault:"false"`
+	BootstrapCachePath   string `env:"MG_AGENT_BOOTSTRAP_CACHE_PATH"          envDefault:"/var/lib/agent/bootstrap.json"`
 	ClientsURL           string `env:"MG_AGENT_CLIENTS_URL"                   envDefault:""`
 	ChannelsURL          string `env:"MG_AGENT_CHANNELS_URL"                  envDefault:""`
 	RulesEngineURL       string `env:"MG_AGENT_RULES_ENGINE_URL"              envDefault:""`
@@ -105,21 +106,29 @@ func main() {
 	stream := logstream.New()
 	logger = slog.New(logstream.NewHandler(logger.Handler(), stream))
 
-	if hasBootstrapConfig(c) {
-		cfg, err = loadBootConfig(cfg, c, logger)
-		if err != nil {
-			logger.Error("Failed to load bootstrap config", slog.Any("error", err))
-			exitCode = 1
-			return
-		}
-	}
-
 	store, err := pkgconfig.NewStore(c.ConfigPath)
 	if err != nil {
 		logger.Error("Failed to open persistent config store", slog.Any("error", err))
 		exitCode = 1
 		return
 	}
+
+	if hasBootstrapConfig(c) {
+		forceFetch := false
+		if val, ok := store.Get("bs_valid"); ok && val == "0" {
+			forceFetch = true
+		}
+		cfg, err = loadBootConfig(cfg, c, logger, forceFetch)
+		if err != nil {
+			logger.Error("Failed to load bootstrap config", slog.Any("error", err))
+			exitCode = 1
+			return
+		}
+		if err := store.Set("bs_valid", "1"); err != nil {
+			logger.Warn("Failed to persist bs_valid flag", slog.Any("error", err))
+		}
+	}
+
 	cfg = applyPersistedOverrides(cfg, store)
 	// Sync the live log-level variable with any persisted log_level override.
 	if val, ok := store.Get("log_level"); ok {
@@ -187,7 +196,7 @@ func main() {
 		}
 	}()
 
-	svc, err := agent.New(ctx, mqttClient, &cfg, noderedClient, logger, devices, store, levelVar)
+	svc, err := agent.New(ctx, mqttClient, &cfg, noderedClient, logger, devices, store, levelVar, c.BootstrapCachePath)
 	if err != nil {
 		logger.Error("Error in agent service", slog.Any("error", err))
 		exitCode = 1
@@ -474,7 +483,7 @@ func applyPersistedOverrides(cfg agent.Config, store pkgconfig.Store) agent.Conf
 	return cfg
 }
 
-func loadBootConfig(c agent.Config, cfg config, logger *slog.Logger) (agent.Config, error) {
+func loadBootConfig(c agent.Config, cfg config, logger *slog.Logger, forceFetch bool) (agent.Config, error) {
 	missing := []string{}
 	if cfg.BootstrapURL == "" {
 		missing = append(missing, "MG_AGENT_BOOTSTRAP_URL")
@@ -501,9 +510,10 @@ func loadBootConfig(c agent.Config, cfg config, logger *slog.Logger) (agent.Conf
 		Retries:       cfg.BootstrapRetries,
 		RetryDelaySec: cfg.BootstrapRetryDelay,
 		SkipTLS:       skipTLS,
+		CachePath:     cfg.BootstrapCachePath,
 	}
 
-	bsc, err := bootstrap.FetchAgentConfig(bsConfig, c, logger)
+	bsc, err := bootstrap.FetchAgentConfig(bsConfig, c, logger, forceFetch)
 	if err != nil {
 		return c, errors.Wrap(errFetchingBootstrapFailed, err)
 	}

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -28,6 +30,7 @@ type Config struct {
 	RetryDelaySec string
 	Encrypt       string
 	SkipTLS       bool
+	CachePath     string
 }
 
 // renderedContent holds the device configuration rendered by the bootstrap
@@ -72,7 +75,19 @@ type bootstrapResponse struct {
 
 // FetchAgentConfig retrieves device configuration from the bootstrap service and
 // overlays the returned credentials and channel IDs onto agentCfg.
-func FetchAgentConfig(cfg Config, agentCfg agent.Config, logger *slog.Logger) (agent.Config, error) {
+// When cfg.CachePath is set and forceFetch is false, it first attempts to load
+// a previously cached response from disk. On cache miss it fetches from the
+// bootstrap service and writes the response to cfg.CachePath.
+func FetchAgentConfig(cfg Config, agentCfg agent.Config, logger *slog.Logger, forceFetch bool) (agent.Config, error) {
+	if !forceFetch && cfg.CachePath != "" {
+		br, err := loadFromCache(cfg.CachePath)
+		if err == nil {
+			logger.Info("Loaded bootstrap config from cache", slog.String("path", cfg.CachePath))
+			return applyBootstrapResponse(agentCfg, br)
+		}
+		logger.Info("Bootstrap cache miss, fetching from service", slog.String("path", cfg.CachePath), slog.Any("cache_error", err))
+	}
+
 	retries, err := strconv.ParseUint(cfg.Retries, 10, 64)
 	if err != nil {
 		return agentCfg, errors.New(fmt.Sprintf("Invalid BOOTSTRAP_RETRIES value: %s", err))
@@ -105,6 +120,14 @@ func FetchAgentConfig(cfg Config, agentCfg agent.Config, logger *slog.Logger) (a
 	}
 	if fetchErr != nil {
 		return agentCfg, fmt.Errorf("bootstrap retries exhausted: %w", fetchErr)
+	}
+
+	if cfg.CachePath != "" {
+		if cacheErr := storeToCache(cfg.CachePath, br); cacheErr != nil {
+			logger.Warn("Failed to cache bootstrap response", slog.Any("error", cacheErr))
+		} else {
+			logger.Info("Cached bootstrap response", slog.String("path", cfg.CachePath))
+		}
 	}
 
 	return applyBootstrapResponse(agentCfg, br)
@@ -228,4 +251,35 @@ func getConfig(bsID, bsKey, bsSvrURL string, skipTLS bool, logger *slog.Logger) 
 
 func bootstrapConfigURL(bsSvrURL, bsID string) string {
 	return fmt.Sprintf("%s/%s", strings.TrimRight(bsSvrURL, "/"), strings.TrimLeft(bsID, "/"))
+}
+
+func loadFromCache(path string) (bootstrapResponse, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return bootstrapResponse{}, err
+	}
+	var br bootstrapResponse
+	if err := json.Unmarshal(data, &br); err != nil {
+		return bootstrapResponse{}, err
+	}
+	if br.Content == "" {
+		return bootstrapResponse{}, errors.New("cached bootstrap response has empty content")
+	}
+	return br, nil
+}
+
+func storeToCache(path string, br bootstrapResponse) error {
+	data, err := json.MarshalIndent(br, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -85,7 +85,7 @@ func FetchAgentConfig(cfg Config, agentCfg agent.Config, logger *slog.Logger, fo
 			logger.Info("Loaded bootstrap config from cache", slog.String("path", cfg.CachePath))
 			return applyBootstrapResponse(agentCfg, br)
 		}
-		logger.Info("Bootstrap cache miss, fetching from service", slog.String("path", cfg.CachePath), slog.Any("cache_error", err))
+		logger.Info("Bootstrap cache miss, fetching from service", slog.String("path", cfg.CachePath), slog.Any("error", err))
 	}
 
 	retries, err := strconv.ParseUint(cfg.Retries, 10, 64)
@@ -265,6 +265,9 @@ func loadFromCache(path string) (bootstrapResponse, error) {
 	if br.Content == "" {
 		return bootstrapResponse{}, errors.New("cached bootstrap response has empty content")
 	}
+	if br.ClientKey == "" || br.ClientCert == "" {
+		return bootstrapResponse{}, errors.New("cached bootstrap response has empty credentials")
+	}
 	return br, nil
 }
 
@@ -281,5 +284,9 @@ func storeToCache(path string, br bootstrapResponse) error {
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
 }

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -4,12 +4,16 @@
 package bootstrap
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/absmach/agent"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApplyBootstrapResponse(t *testing.T) {
@@ -163,4 +167,97 @@ func TestBootstrapConfigURL(t *testing.T) {
 			assert.Equal(t, tc.url, got, fmt.Sprintf("%s: expected url %s got %s", tc.desc, tc.url, got))
 		})
 	}
+}
+
+func TestLoadFromCache(t *testing.T) {
+	cases := []struct {
+		desc    string
+		setup   func(t *testing.T, path string)
+		err     bool
+		content string
+	}{
+		{
+			desc: "load valid cache",
+			setup: func(t *testing.T, path string) {
+				br := bootstrapResponse{
+					Content:    `{"device_id":"dev1"}`,
+					ClientKey:  "key",
+					ClientCert: "cert",
+					CaCert:     "ca",
+				}
+				data, err := json.Marshal(br)
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, data, 0o600))
+			},
+			content: `{"device_id":"dev1"}`,
+		},
+		{
+			desc: "missing file returns error",
+			setup: func(t *testing.T, path string) {
+			},
+			err: true,
+		},
+		{
+			desc: "corrupt json returns error",
+			setup: func(t *testing.T, path string) {
+				require.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+			},
+			err: true,
+		},
+		{
+			desc: "empty content returns error",
+			setup: func(t *testing.T, path string) {
+				br := bootstrapResponse{Content: ""}
+				data, err := json.Marshal(br)
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, data, 0o600))
+			},
+			err: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "bootstrap.json")
+			tc.setup(t, path)
+			br, err := loadFromCache(path)
+			if tc.err {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.content, br.Content)
+		})
+	}
+}
+
+func TestStoreToCache(t *testing.T) {
+	br := bootstrapResponse{
+		Content:    `{"device_id":"dev1"}`,
+		ClientKey:  "key",
+		ClientCert: "cert",
+		CaCert:     "ca",
+	}
+
+	t.Run("store and reload", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "subdir", "bootstrap.json")
+		require.NoError(t, storeToCache(path, br))
+		got, err := loadFromCache(path)
+		assert.NoError(t, err)
+		assert.Equal(t, br.Content, got.Content)
+		assert.Equal(t, br.ClientKey, got.ClientKey)
+		assert.Equal(t, br.ClientCert, got.ClientCert)
+		assert.Equal(t, br.CaCert, got.CaCert)
+	})
+
+	t.Run("overwrites existing cache", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bootstrap.json")
+		require.NoError(t, storeToCache(path, bootstrapResponse{Content: `{"old":true}`}))
+		require.NoError(t, storeToCache(path, br))
+		got, err := loadFromCache(path)
+		assert.NoError(t, err)
+		assert.Equal(t, br.Content, got.Content)
+	})
 }

--- a/pkg/ota/ota.go
+++ b/pkg/ota/ota.go
@@ -67,6 +67,12 @@ type Trigger struct {
 	Size      uint64 // expected byte count, 0 means no size check
 }
 
+const (
+	otaFieldName = "url"
+	otaFieldHash = "hash"
+	otaFieldSize = "size"
+)
+
 // TriggerFromRecords parses OTA trigger fields from the SenML records that
 // follow the dispatch record. The full wire format (all records in the pack) is:
 //
@@ -80,16 +86,16 @@ func TriggerFromRecords(records []senml.Record) (Trigger, error) {
 	var t Trigger
 	for _, r := range records {
 		switch r.Name {
-		case "url":
+		case otaFieldName:
 			if r.StringValue == nil || strings.TrimSpace(*r.StringValue) == "" {
 				return Trigger{}, fmt.Errorf("ota trigger: url record has no value")
 			}
 			t.URL = strings.TrimSpace(*r.StringValue)
-		case "hash":
+		case otaFieldHash:
 			if r.StringValue != nil {
 				t.SHA256Hex = *r.StringValue
 			}
-		case "size":
+		case otaFieldSize:
 			if r.Value != nil {
 				t.Size = uint64(*r.Value)
 			}

--- a/service.go
+++ b/service.go
@@ -53,6 +53,7 @@ const (
 	keyHeartbeatInterval      = "heartbeat_interval"
 	keyTerminalSessionTimeout = "terminal_session_timeout"
 	keyCommandSecret          = "command_secret"
+	keyBsValid                = "bs_valid"
 
 	notConfigured = "not_configured"
 	notFound      = "not_found"
@@ -225,10 +226,11 @@ type agent struct {
 	startupConfig       Config
 	otaMu               sync.Mutex
 	otaLastErr          string
+	bootstrapCachePath  string
 }
 
 // New returns agent service implementation.
-func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, logger *slog.Logger, devices *devicemgr.Manager, store cfgstore.Store, levelVar *slog.LevelVar) (Service, error) {
+func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, logger *slog.Logger, devices *devicemgr.Manager, store cfgstore.Store, levelVar *slog.LevelVar, bootstrapCachePath string) (Service, error) {
 	ag := &agent{
 		mqttClient:          mc,
 		noderedClient:       nc,
@@ -242,6 +244,7 @@ func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, lo
 		heartbeatIntervalCh: make(chan time.Duration, 1),
 		logLevel:            levelVar,
 		startupConfig:       *cfg,
+		bootstrapCachePath:  bootstrapCachePath,
 	}
 
 	if devices != nil {
@@ -1052,6 +1055,7 @@ var settableKeys = map[string]bool{
 	keyHeartbeatInterval:      true,
 	keyTerminalSessionTimeout: true,
 	keyCommandSecret:          true,
+	keyBsValid:                true,
 }
 
 // validateSettableValue returns errInvalidCommand if val is not a valid value for key.
@@ -1074,6 +1078,10 @@ func validateSettableValue(key, val string) error {
 		}
 	case keyCommandSecret:
 		// Any non-empty string is valid; empty value clears the secret.
+	case keyBsValid:
+		if val != "0" && val != "1" {
+			return errInvalidCommand
+		}
 	default:
 		return errInvalidCommand
 	}
@@ -1128,6 +1136,14 @@ func ApplyConfigEntry(cfg *Config, key, val string) {
 // effect is immediate without requiring a restart.
 func (a *agent) applyLiveUpdate(key, val string) {
 	switch key {
+	case keyBsValid:
+		if val == "0" && a.bootstrapCachePath != "" {
+			if err := os.Remove(a.bootstrapCachePath); err != nil && !os.IsNotExist(err) {
+				a.logger.Warn("Failed to delete bootstrap cache", slog.Any("error", err))
+			} else {
+				a.logger.Info("Bootstrap cache invalidated")
+			}
+		}
 	case keyLogLevel:
 		if a.logLevel != nil {
 			var l slog.Level

--- a/service.go
+++ b/service.go
@@ -1138,8 +1138,10 @@ func (a *agent) applyLiveUpdate(key, val string) {
 	switch key {
 	case keyBsValid:
 		if val == "0" && a.bootstrapCachePath != "" {
-			if err := os.Remove(a.bootstrapCachePath); err != nil && !os.IsNotExist(err) {
-				a.logger.Warn("Failed to delete bootstrap cache", slog.Any("error", err))
+			if err := os.Remove(a.bootstrapCachePath); err != nil {
+				if !os.IsNotExist(err) {
+					a.logger.Warn("Failed to delete bootstrap cache", slog.Any("error", err))
+				}
 			} else {
 				a.logger.Info("Bootstrap cache invalidated")
 			}

--- a/service_test.go
+++ b/service_test.go
@@ -751,6 +751,7 @@ func TestBsValidCacheInvalidation(t *testing.T) {
 	hbToken.On("Error").Maybe().Return(error(nil))
 	mqttClient.On("Publish", mqttTopic("data-channel", "gateway/heartbeat"),
 		mock.Anything, mock.Anything, mock.Anything).Maybe().Return(hbToken)
+	mqttClient.On("IsConnected").Maybe().Return(true)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

--- a/service_test.go
+++ b/service_test.go
@@ -72,7 +72,7 @@ func newServiceWithStore(t *testing.T, cfg agent.Config, store cfgstore.Store) (
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, store, nil)
+	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, store, nil, "")
 	return svc, mqttClient, nodeRed, err
 }
 
@@ -100,7 +100,7 @@ func newService(t *testing.T, cfg agent.Config, devices ...*devicemgr.Manager) (
 		mgr = devices[0]
 	}
 
-	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), mgr, nil, nil)
+	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), mgr, nil, nil, "")
 	return svc, mqttClient, nodeRed, err
 }
 
@@ -649,6 +649,12 @@ func TestConfigGetSet(t *testing.T) {
 			wantResp: "ok",
 		},
 		{
+			desc:     "set bs_valid to 1",
+			cmd:      "set,bs_valid,1",
+			useStore: true,
+			wantResp: "ok",
+		},
+		{
 			desc:     "get command_secret returns redacted",
 			cmd:      "get,command_secret",
 			useStore: true,
@@ -660,6 +666,38 @@ func TestConfigGetSet(t *testing.T) {
 			cmd:      "reset,command_secret",
 			useStore: true,
 			seed:     map[string]string{"command_secret": "my-secret-token"},
+			wantResp: "ok",
+		},
+		{
+			desc:     "set bs_valid to 0",
+			cmd:      "set,bs_valid,0",
+			useStore: true,
+			wantResp: "ok",
+		},
+		{
+			desc:     "reject set bs_valid with invalid value",
+			cmd:      "set,bs_valid,2",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "reject set bs_valid with non-numeric value",
+			cmd:      "set,bs_valid,yes",
+			useStore: true,
+			err:      true,
+		},
+		{
+			desc:     "get bs_valid after set",
+			cmd:      "get,bs_valid",
+			useStore: true,
+			seed:     map[string]string{"bs_valid": "1"},
+			wantResp: "1",
+		},
+		{
+			desc:     "reset bs_valid",
+			cmd:      "reset,bs_valid",
+			useStore: true,
+			seed:     map[string]string{"bs_valid": "1"},
 			wantResp: "ok",
 		},
 	}
@@ -693,6 +731,45 @@ func TestConfigGetSet(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBsValidCacheInvalidation(t *testing.T) {
+	cacheDir := t.TempDir()
+	cachePath := filepath.Join(cacheDir, "bootstrap.json")
+	require.NoError(t, os.WriteFile(cachePath, []byte(`{"content":"cached"}`), 0o600))
+
+	s, storeErr := cfgstore.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	require.NoError(t, storeErr)
+
+	cfg := testConfig()
+	cfg.DomainID = domainID
+	mqttClient := agentmocks.NewMQTTClient(t)
+	nodeRed := nrmocks.NewClient(t)
+
+	hbToken := agentmocks.NewMQTTToken(t)
+	hbToken.On("Wait").Maybe().Return(true)
+	hbToken.On("Error").Maybe().Return(error(nil))
+	mqttClient.On("Publish", mqttTopic("data-channel", "gateway/heartbeat"),
+		mock.Anything, mock.Anything, mock.Anything).Maybe().Return(hbToken)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	svc, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, s, nil, cachePath)
+	require.NoError(t, err)
+
+	assert.FileExists(t, cachePath, "cache file should exist before invalidation")
+
+	respToken := agentmocks.NewMQTTToken(t)
+	respToken.On("Wait").Return(true).Once()
+	respToken.On("Error").Return(error(nil)).Once()
+	mqttClient.On("Publish", mqttTopic("ctrl-channel", "res"), mock.Anything, mock.Anything, mock.Anything).Return(respToken).Once()
+
+	err = svc.ServiceConfig(context.Background(), "uuid", "set,bs_valid,0")
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(cachePath)
+	assert.True(t, os.IsNotExist(statErr), "cache file should be deleted after bs_valid=0")
 }
 
 func TestApplyConfigEntry(t *testing.T) {

--- a/service_test.go
+++ b/service_test.go
@@ -133,7 +133,7 @@ func TestSelfHeartbeatPublishesRichPayload(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, nil)
+	_, err := agent.New(ctx, mqttClient, &cfg, nodeRed, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, nil, "")
 	require.NoError(t, err)
 
 	select {


### PR DESCRIPTION
### What does this do?

Caches the bootstrap response to a local file so the agent doesn't re-fetch from the bootstrap service on every restart. On startup, if a valid cache exists, it is used directly. If the cache is missing, corrupt, or explicitly invalidated, the agent fetches fresh config from the bootstrap service and writes it to cache.

### Which issue(s) does this fix/relate to?

Resolves #32

### List any changes that modify/break current functionality

- `bootstrap.FetchAgentConfig` signature changed: added `forceFetch bool` parameter
- `agent.New` signature changed: added `bootstrapCachePath string` parameter
- Config store is now opened before bootstrap runs (previously opened after)

### Have you included tests for your changes?

Yes

### Did you document any new/modified functionality?

No

### Notes

Mirrors the Aeolus `bootstrap_load_nvs()` / `bootstrap_store_nvs()` pattern (`src/bootstrap/bootstrap.c`). Cache writes are atomic (write to `.tmp`, then `os.Rename`).
