### PR TITLE
AG - 40 - Persist bootstrap fields and skip fetch if present

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -129,7 +129,7 @@ func main() {
 				exitCode = 1
 				return
 			}
-			persistBootstrapFields(store, cfg)
+			persistBootstrapFields(store, cfg, logger)
 			if err := store.Set("bs_valid", "1"); err != nil {
 				logger.Warn("Failed to persist bs_valid flag", slog.Any("error", err))
 			}
@@ -283,19 +283,44 @@ func hasBootstrapCredentials(cfg agent.Config) bool {
 	if cfg.MQTT.URL == "" {
 		return false
 	}
-	if !cfg.MQTT.MTLS && (cfg.MQTT.Username == "" || cfg.MQTT.Password == "") {
+	if cfg.MQTT.MTLS {
+		if cfg.MQTT.ClientCert == "" || cfg.MQTT.ClientKey == "" {
+			if cfg.MQTT.CertPath == "" || cfg.MQTT.PrivKeyPath == "" {
+				return false
+			}
+		}
+	} else if cfg.MQTT.Username == "" || cfg.MQTT.Password == "" {
 		return false
 	}
 	return true
 }
 
-func persistBootstrapFields(store pkgconfig.Store, cfg agent.Config) {
-	_ = store.Set("domain_id", cfg.DomainID)
-	_ = store.Set("channels_ctrl_id", cfg.Channels.CtrlID)
-	_ = store.Set("channels_data_id", cfg.Channels.DataID)
-	_ = store.Set("mqtt_url", cfg.MQTT.URL)
-	_ = store.Set("mqtt_username", cfg.MQTT.Username)
-	_ = store.Set("mqtt_password", cfg.MQTT.Password)
+// persistBootstrapFields writes the critical bootstrap-derived fields to the
+// persistent config store so they survive agent restarts and allow the
+// bootstrap HTTP fetch to be skipped on subsequent runs.
+//
+// The MQTT password is stored in plaintext in agent-config.json. The file is
+// created with 0o600 permissions (owner read/write only) and the password is
+// needed to reconnect when mTLS is not in use.
+func persistBootstrapFields(store pkgconfig.Store, cfg agent.Config, logger *slog.Logger) {
+	if err := store.Set("domain_id", cfg.DomainID); err != nil {
+		logger.Warn("Failed to persist domain_id", slog.Any("error", err))
+	}
+	if err := store.Set("channels_ctrl_id", cfg.Channels.CtrlID); err != nil {
+		logger.Warn("Failed to persist channels_ctrl_id", slog.Any("error", err))
+	}
+	if err := store.Set("channels_data_id", cfg.Channels.DataID); err != nil {
+		logger.Warn("Failed to persist channels_data_id", slog.Any("error", err))
+	}
+	if err := store.Set("mqtt_url", cfg.MQTT.URL); err != nil {
+		logger.Warn("Failed to persist mqtt_url", slog.Any("error", err))
+	}
+	if err := store.Set("mqtt_username", cfg.MQTT.Username); err != nil {
+		logger.Warn("Failed to persist mqtt_username", slog.Any("error", err))
+	}
+	if err := store.Set("mqtt_password", cfg.MQTT.Password); err != nil {
+		logger.Warn("Failed to persist mqtt_password", slog.Any("error", err))
+	}
 }
 
 func loadEnvConfig(cfg config) (agent.Config, error) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,23 +115,30 @@ func main() {
 		return
 	}
 
+	cfg = applyPersistedOverrides(cfg, store)
+
 	if hasBootstrapConfig(c) {
 		forceFetch := false
 		if val, ok := store.Get("bs_valid"); ok && val == "0" {
 			forceFetch = true
 		}
-		cfg, err = loadBootConfig(cfg, c, logger, forceFetch)
-		if err != nil {
-			logger.Error("Failed to load bootstrap config", slog.Any("error", err))
-			exitCode = 1
-			return
-		}
-		if err := store.Set("bs_valid", "1"); err != nil {
-			logger.Warn("Failed to persist bs_valid flag", slog.Any("error", err))
+		if forceFetch || !hasBootstrapCredentials(cfg) {
+			cfg, err = loadBootConfig(cfg, c, logger, forceFetch)
+			if err != nil {
+				logger.Error("Failed to load bootstrap config", slog.Any("error", err))
+				exitCode = 1
+				return
+			}
+			persistBootstrapFields(store, cfg)
+			if err := store.Set("bs_valid", "1"); err != nil {
+				logger.Warn("Failed to persist bs_valid flag", slog.Any("error", err))
+			}
+			cfg = applyPersistedOverrides(cfg, store)
+		} else {
+			logger.Info("Bootstrap data already present, skipping bootstrap fetch")
 		}
 	}
 
-	cfg = applyPersistedOverrides(cfg, store)
 	// Sync the live log-level variable with any persisted log_level override.
 	if val, ok := store.Get("log_level"); ok {
 		var l slog.Level
@@ -264,6 +271,31 @@ func validateRuntimeConfig(cfg agent.Config) error {
 
 func hasBootstrapConfig(cfg config) bool {
 	return cfg.BootstrapURL != "" && cfg.BootstrapExternalID != "" && cfg.BootstrapExternalKey != ""
+}
+
+func hasBootstrapCredentials(cfg agent.Config) bool {
+	if cfg.DomainID == "" {
+		return false
+	}
+	if cfg.Channels.CtrlID == "" || cfg.Channels.DataID == "" {
+		return false
+	}
+	if cfg.MQTT.URL == "" {
+		return false
+	}
+	if !cfg.MQTT.MTLS && (cfg.MQTT.Username == "" || cfg.MQTT.Password == "") {
+		return false
+	}
+	return true
+}
+
+func persistBootstrapFields(store pkgconfig.Store, cfg agent.Config) {
+	_ = store.Set("domain_id", cfg.DomainID)
+	_ = store.Set("channels_ctrl_id", cfg.Channels.CtrlID)
+	_ = store.Set("channels_data_id", cfg.Channels.DataID)
+	_ = store.Set("mqtt_url", cfg.MQTT.URL)
+	_ = store.Set("mqtt_username", cfg.MQTT.Username)
+	_ = store.Set("mqtt_password", cfg.MQTT.Password)
 }
 
 func loadEnvConfig(cfg config) (agent.Config, error) {

--- a/service.go
+++ b/service.go
@@ -55,6 +55,12 @@ const (
 	keyTerminalSessionTimeout = "terminal_session_timeout"
 	keyCommandSecret          = "command_secret"
 	keyBsValid                = "bs_valid"
+	keyDomainID               = "domain_id"
+	keyChannelsCtrlID         = "channels_ctrl_id"
+	keyChannelsDataID         = "channels_data_id"
+	keyMqttURL                = "mqtt_url"
+	keyMqttUsername           = "mqtt_username"
+	keyMqttPassword           = "mqtt_password"
 
 	notConfigured = "not_configured"
 	notFound      = "not_found"
@@ -1223,6 +1229,18 @@ func ApplyConfigEntry(cfg *Config, key, val string) {
 		}
 	case keyCommandSecret:
 		cfg.CommandSecret = val
+	case keyDomainID:
+		cfg.DomainID = val
+	case keyChannelsCtrlID:
+		cfg.Channels.CtrlID = val
+	case keyChannelsDataID:
+		cfg.Channels.DataID = val
+	case keyMqttURL:
+		cfg.MQTT.URL = val
+	case keyMqttUsername:
+		cfg.MQTT.Username = val
+	case keyMqttPassword:
+		cfg.MQTT.Password = val
 	}
 }
 

--- a/service.go
+++ b/service.go
@@ -1211,6 +1211,10 @@ func (a *agent) revertToStartup(key string) {
 
 // ApplyConfigEntry updates cfg in place for the known settable keys.
 // Used at startup to replay persisted overrides before the agent starts.
+//
+// Keys for bootstrap-derived fields (domain_id, channels_*, mqtt_*) are
+// applied at startup only. They are not included in settableKeys and
+// cannot be modified via runtime MQTT set commands.
 func ApplyConfigEntry(cfg *Config, key, val string) {
 	switch key {
 	case keyLogLevel:

--- a/service_test.go
+++ b/service_test.go
@@ -920,8 +920,8 @@ func TestApplyConfigEntry(t *testing.T) {
 		},
 		{
 			desc: "unknown key is a no-op",
-			key:  "mqtt_password",
-			val:  "secret",
+			key:  "nonexistent_key",
+			val:  "some_value",
 			check: func(t *testing.T, cfg agent.Config) {
 				assert.Equal(t, "client-secret", cfg.MQTT.Password)
 			},
@@ -932,6 +932,54 @@ func TestApplyConfigEntry(t *testing.T) {
 			val:  "my-secret-token",
 			check: func(t *testing.T, cfg agent.Config) {
 				assert.Equal(t, "my-secret-token", cfg.CommandSecret)
+			},
+		},
+		{
+			desc: "set domain id",
+			key:  "domain_id",
+			val:  "my-domain",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, "my-domain", cfg.DomainID)
+			},
+		},
+		{
+			desc: "set channels ctrl id",
+			key:  "channels_ctrl_id",
+			val:  "new-ctrl-channel",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, "new-ctrl-channel", cfg.Channels.CtrlID)
+			},
+		},
+		{
+			desc: "set channels data id",
+			key:  "channels_data_id",
+			val:  "new-data-channel",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, "new-data-channel", cfg.Channels.DataID)
+			},
+		},
+		{
+			desc: "set mqtt url",
+			key:  "mqtt_url",
+			val:  "ssl://new-broker.example.com:8883",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, "ssl://new-broker.example.com:8883", cfg.MQTT.URL)
+			},
+		},
+		{
+			desc: "set mqtt username",
+			key:  "mqtt_username",
+			val:  "new-username",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, "new-username", cfg.MQTT.Username)
+			},
+		},
+		{
+			desc: "set mqtt password",
+			key:  "mqtt_password",
+			val:  "new-secret",
+			check: func(t *testing.T, cfg agent.Config) {
+				assert.Equal(t, "new-secret", cfg.MQTT.Password)
 			},
 		},
 	}


### PR DESCRIPTION
## What does this do?

Skips the bootstrap HTTP fetch when the agent already has valid runtime credentials from a previous run. 

On startup, the agent now checks whether `domain_id`, channels (`ctrl_id` / `data_id`), and MQTT credentials (URL + username/password, or mTLS) are already present before calling `bootstrap.FetchAgentConfig()`. After a successful bootstrap, these fields are persisted to the config store (`agent-config.json`) so they survive restarts. On subsequent starts the agent loads them from the store, detects they're already present, and skips the fetch entirely.

A `bs_valid=0` flag in the config store still forces a fresh fetch regardless.

## Which issue(s) does this PR fix/relate to?

Resolves #40

## List any changes that modify/break current functionality

None. The change is additive — if credentials aren't present the bootstrap flow runs as before. The `bs_valid` flag mechanism is preserved unchanged.

## Have you included tests for your changes?

Yes — added 6 test cases to `TestApplyConfigEntry` covering the new config keys (`domain_id`, `channels_ctrl_id`, `channels_data_id`, `mqtt_url`, `mqtt_username`, `mqtt_password`). Fixed the existing "unknown key is a no-op" test which previously used `mqtt_password` as an unknown key.

## Did you document any new/modified functionality?

No documentation changes — the behavior is transparent to end users.
