### PR TITLE
AG - 38 - Add health supervisor and MQTT checker feature

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -225,10 +225,15 @@ func main() {
 	// the process if the agent remains unhealthy for longer than the timeout.
 	// When running under systemd, it also sends periodic WATCHDOG=1
 	// notifications via the NOTIFY_SOCKET.
-	wdInterval, _ := time.ParseDuration(c.WatchdogInterval)
-	wdTimeout, _ := time.ParseDuration(c.WatchdogTimeout)
-	if wdInterval <= 0 {
-		wdTimeout, _ = time.ParseDuration("60s")
+	wdInterval, err := time.ParseDuration(c.WatchdogInterval)
+	if err != nil {
+		logger.Warn("Invalid watchdog interval, disabling watchdog", slog.String("interval", c.WatchdogInterval), slog.Any("error", err))
+		wdInterval = 0
+	}
+	wdTimeout, err := time.ParseDuration(c.WatchdogTimeout)
+	if err != nil {
+		logger.Warn("Invalid watchdog timeout, using default 60s", slog.String("timeout", c.WatchdogTimeout), slog.Any("error", err))
+		wdTimeout = 60 * time.Second
 	}
 	sup := health.NewSupervisor(health.Config{
 		Interval: wdInterval,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	pkgconfig "github.com/absmach/agent/pkg/config"
 	"github.com/absmach/agent/pkg/conn"
 	"github.com/absmach/agent/pkg/devicemgr"
+	"github.com/absmach/agent/pkg/health"
 	"github.com/absmach/agent/pkg/iface"
 	"github.com/absmach/agent/pkg/logstream"
 	"github.com/absmach/agent/pkg/nodered"
@@ -69,6 +70,8 @@ type config struct {
 	DeviceDBPath         string `env:"MG_AGENT_DEVICE_DB_PATH"                envDefault:"/var/lib/agent/devices.db"`
 	ConfigPath           string `env:"MG_AGENT_CONFIG_PATH"                   envDefault:"agent-config.json"`
 	CommandSecret        string `env:"MG_AGENT_COMMAND_SECRET"                envDefault:""`
+	WatchdogInterval     string `env:"MG_AGENT_WATCHDOG_INTERVAL"            envDefault:"0s"`
+	WatchdogTimeout      string `env:"MG_AGENT_WATCHDOG_TIMEOUT"             envDefault:"60s"`
 }
 
 var (
@@ -218,6 +221,21 @@ func main() {
 	b := conn.NewBroker(svc, mqttClient, cfg.Channels.CtrlChan(), cfg.DomainID, logger)
 	onReconnect = b.Resubscribe
 
+	// Health supervisor: periodically checks subsystem liveness and restarts
+	// the process if the agent remains unhealthy for longer than the timeout.
+	// When running under systemd, it also sends periodic WATCHDOG=1
+	// notifications via the NOTIFY_SOCKET.
+	wdInterval, _ := time.ParseDuration(c.WatchdogInterval)
+	wdTimeout, _ := time.ParseDuration(c.WatchdogTimeout)
+	if wdInterval <= 0 {
+		wdTimeout, _ = time.ParseDuration("60s")
+	}
+	sup := health.NewSupervisor(health.Config{
+		Interval: wdInterval,
+		Timeout:  wdTimeout,
+	}, logger)
+	sup.Register(health.NewMQTTChecker(mqttClient))
+
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%s", cfg.Server.Port),
 		Handler: api.MakeHandler(svc, logger, stream, ""),
@@ -235,6 +253,12 @@ func main() {
 	g.Go(func() error {
 		return StopSignalHandler(ctx, cancel, logger, "agent", srv, svc.Shutdown)
 	})
+
+	if wdInterval > 0 {
+		g.Go(func() error {
+			return sup.Run(ctx)
+		})
+	}
 
 	if err := g.Wait(); err != nil {
 		logger.Error("Agent terminated", slog.Any("error", err))

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,185 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package health
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// MQTTClient is the subset of the Paho MQTT client interface required for
+// health checks.
+type MQTTClient interface {
+	IsConnected() bool
+}
+
+// HealthChecker is the interface for subsystem health checks.
+type HealthChecker interface {
+	Name() string
+	Healthy() bool
+}
+
+// Config holds the health supervisor configuration.
+type Config struct {
+	// Interval is how often to run health checks. Zero disables supervision.
+	Interval time.Duration
+	// Timeout is how long the agent can be unhealthy before triggering a
+	// restart. Defaults to 60s if zero.
+	Timeout time.Duration
+}
+
+// Supervisor periodically checks registered health checkers and triggers a
+// process restart if the agent remains unhealthy for longer than the
+// configured timeout.
+type Supervisor struct {
+	checkers []HealthChecker
+	interval time.Duration
+	timeout  time.Duration
+	logger   *slog.Logger
+	healthy  atomic.Bool
+}
+
+// NewSupervisor creates a new health supervisor. If cfg.Interval is zero the
+// supervisor is effectively disabled.
+func NewSupervisor(cfg Config, logger *slog.Logger) *Supervisor {
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 60 * time.Second
+	}
+	s := &Supervisor{
+		interval: cfg.Interval,
+		timeout:  timeout,
+		logger:   logger,
+	}
+	s.healthy.Store(true)
+	return s
+}
+
+// Register adds a health checker to the supervisor.
+func (s *Supervisor) Register(c HealthChecker) {
+	s.checkers = append(s.checkers, c)
+}
+
+// Run starts the health check loop. It blocks until ctx is cancelled.
+// When running under systemd (NOTIFY_SOCKET is set), it also sends periodic
+// WATCHDOG=1 notifications.
+func (s *Supervisor) Run(ctx context.Context) error {
+	if s.interval <= 0 {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	// Start systemd watchdog notifier if applicable.
+	socketPath := os.Getenv("NOTIFY_SOCKET")
+	if socketPath != "" {
+		s.logger.Info("Running under systemd watchdog", slog.String("socket", socketPath))
+		go s.sdWatchdogLoop(ctx, socketPath)
+	}
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	unhealthySince := time.Time{}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			anyUnhealthy := false
+			for _, c := range s.checkers {
+				if !c.Healthy() {
+					s.logger.Warn("Health check failed", slog.String("checker", c.Name()))
+					anyUnhealthy = true
+				}
+			}
+
+			if anyUnhealthy {
+				if unhealthySince.IsZero() {
+					unhealthySince = time.Now()
+				}
+				if time.Since(unhealthySince) >= s.timeout {
+					s.logger.Error("Agent unhealthy for too long, restarting",
+						slog.Duration("duration", time.Since(unhealthySince)),
+						slog.Duration("timeout", s.timeout))
+					s.restart()
+				}
+			} else {
+				if !s.healthy.Load() {
+					s.logger.Info("Agent recovered to healthy state")
+				}
+				unhealthySince = time.Time{}
+				s.healthy.Store(true)
+			}
+		}
+	}
+}
+
+// restart re-executes the current binary. If the re-exec fails, the process
+// exits with a non-zero status.
+func (s *Supervisor) restart() {
+	s.logger.Info("Restarting agent", slog.String("binary", os.Args[0]))
+	_ = syscall.Exec(os.Args[0], os.Args, os.Environ())
+	// If we reach here the exec failed. Fall through to let the process exit.
+	os.Exit(1)
+}
+
+// sdWatchdogLoop sends periodic WATCHDOG=1 notifications to systemd via the
+// unix socket at socketPath.
+func (s *Supervisor) sdWatchdogLoop(ctx context.Context, socketPath string) {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := sdNotify(socketPath, "WATCHDOG=1\n"); err != nil {
+				s.logger.Warn("Failed to notify systemd watchdog", slog.Any("error", err))
+			}
+		}
+	}
+}
+
+// sdNotify sends a message to the systemd notification socket.
+func sdNotify(socketPath, state string) error {
+	addr := &net.UnixAddr{Name: socketPath, Net: "unixgram"}
+	conn, err := net.DialUnix("unixgram", nil, addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = conn.Write([]byte(state))
+	return err
+}
+
+// IsHealthy returns whether the supervisor currently considers the agent
+// healthy.
+func (s *Supervisor) IsHealthy() bool {
+	return s.healthy.Load()
+}
+
+// MQTTChecker checks if the MQTT client is connected.
+type MQTTChecker struct {
+	client MQTTClient
+}
+
+// NewMQTTChecker creates a health checker for the MQTT connection.
+func NewMQTTChecker(client MQTTClient) *MQTTChecker {
+	return &MQTTChecker{client: client}
+}
+
+func (c *MQTTChecker) Name() string {
+	return "mqtt"
+}
+
+func (c *MQTTChecker) Healthy() bool {
+	return c.client.IsConnected()
+}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -101,6 +101,7 @@ func (s *Supervisor) Run(ctx context.Context) error {
 			}
 
 			if anyUnhealthy {
+				s.healthy.Store(false)
 				if unhealthySince.IsZero() {
 					unhealthySince = time.Now()
 				}
@@ -133,6 +134,14 @@ func (s *Supervisor) restart() {
 // sdWatchdogLoop sends periodic WATCHDOG=1 notifications to systemd via the
 // unix socket at socketPath.
 func (s *Supervisor) sdWatchdogLoop(ctx context.Context, socketPath string) {
+	addr := &net.UnixAddr{Name: socketPath, Net: "unixgram"}
+	conn, err := net.DialUnix("unixgram", nil, addr)
+	if err != nil {
+		s.logger.Warn("Failed to connect to systemd notification socket", slog.Any("error", err))
+		return
+	}
+	defer conn.Close()
+
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
 
@@ -141,23 +150,14 @@ func (s *Supervisor) sdWatchdogLoop(ctx context.Context, socketPath string) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := sdNotify(socketPath, "WATCHDOG=1\n"); err != nil {
+			if !s.healthy.Load() {
+				continue
+			}
+			if _, err := conn.Write([]byte("WATCHDOG=1\n")); err != nil {
 				s.logger.Warn("Failed to notify systemd watchdog", slog.Any("error", err))
 			}
 		}
 	}
-}
-
-// sdNotify sends a message to the systemd notification socket.
-func sdNotify(socketPath, state string) error {
-	addr := &net.UnixAddr{Name: socketPath, Net: "unixgram"}
-	conn, err := net.DialUnix("unixgram", nil, addr)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	_, err = conn.Write([]byte(state))
-	return err
 }
 
 // IsHealthy returns whether the supervisor currently considers the agent

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,19 +17,25 @@ import (
 )
 
 type mockMQTT struct {
+	mu        sync.Mutex
 	connected bool
 }
 
-func (m *mockMQTT) IsConnected() bool { return m.connected }
+func (m *mockMQTT) IsConnected() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.connected
+}
 
 type mockChecker struct {
+	mu      sync.Mutex
 	name    string
 	healthy bool
 }
 
 func (c *mockChecker) Name() string      { return c.name }
-func (c *mockChecker) Healthy() bool     { return c.healthy }
-func (c *mockChecker) SetHealthy(v bool) { c.healthy = v }
+func (c *mockChecker) Healthy() bool     { c.mu.Lock(); defer c.mu.Unlock(); return c.healthy }
+func (c *mockChecker) SetHealthy(v bool) { c.mu.Lock(); defer c.mu.Unlock(); c.healthy = v }
 
 func TestSupervisorDisabled(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -74,11 +81,21 @@ func TestSupervisorUnhealthyTriggersRestart(t *testing.T) {
 	checker := &mockChecker{name: "test", healthy: true}
 	sup.Register(checker)
 
-	// The supervisor goroutine would call os.Exit on unhealthy timeout,
-	// which we can't test. Just verify the checker state changes.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- sup.Run(ctx)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	assert.True(t, sup.IsHealthy())
+
 	checker.SetHealthy(false)
-	time.Sleep(40 * time.Millisecond)
-	assert.False(t, checker.Healthy())
+	time.Sleep(20 * time.Millisecond)
+	assert.False(t, sup.IsHealthy())
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
 }
 
 func TestMQTTChecker(t *testing.T) {

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package health_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/absmach/agent/pkg/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockMQTT struct {
+	connected bool
+}
+
+func (m *mockMQTT) IsConnected() bool { return m.connected }
+
+type mockChecker struct {
+	name    string
+	healthy bool
+}
+
+func (c *mockChecker) Name() string      { return c.name }
+func (c *mockChecker) Healthy() bool     { return c.healthy }
+func (c *mockChecker) SetHealthy(v bool) { c.healthy = v }
+
+func TestSupervisorDisabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	sup := health.NewSupervisor(health.Config{Interval: 0}, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sup.Run(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSupervisorHealthy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	sup := health.NewSupervisor(health.Config{
+		Interval: 10 * time.Millisecond,
+		Timeout:  50 * time.Millisecond,
+	}, logger)
+
+	checker := &mockChecker{name: "test", healthy: true}
+	sup.Register(checker)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- sup.Run(ctx)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	assert.True(t, sup.IsHealthy())
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestSupervisorUnhealthyTriggersRestart(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	sup := health.NewSupervisor(health.Config{
+		Interval: 10 * time.Millisecond,
+		Timeout:  25 * time.Millisecond,
+	}, logger)
+
+	checker := &mockChecker{name: "test", healthy: true}
+	sup.Register(checker)
+
+	// The supervisor goroutine would call os.Exit on unhealthy timeout,
+	// which we can't test. Just verify the checker state changes.
+	checker.SetHealthy(false)
+	time.Sleep(40 * time.Millisecond)
+	assert.False(t, checker.Healthy())
+}
+
+func TestMQTTChecker(t *testing.T) {
+	mock := &mockMQTT{connected: true}
+	checker := health.NewMQTTChecker(mock)
+
+	assert.Equal(t, "mqtt", checker.Name())
+	assert.True(t, checker.Healthy())
+
+	mock.connected = false
+	assert.False(t, checker.Healthy())
+}


### PR DESCRIPTION
## What does this do?

Adds a health watchdog/self-health supervisor that monitors subsystem liveness and restarts the agent when unhealthy for too long.

The supervisor is a background goroutine that periodically checks registered health checkers (currently MQTT connection status). If any checker reports unhealthy for longer than the configured timeout, the agent re-executes itself via `syscall.Exec`.

When running under systemd with `Type=notify`, the supervisor also sends periodic `WATCHDOG=1` notifications through the `NOTIFY_SOCKET` unix datagram socket.

The feature is disabled by default (`MG_AGENT_WATCHDOG_INTERVAL=0s`). Enable with:
```bash
MG_AGENT_WATCHDOG_INTERVAL=10s   # check every 10s MG_AGENT_WATCHDOG_TIMEOUT=60s    # restart after 60s unhealthy
```

## Which issue(s) does this PR fix/relate to?

Resolves #38

## List any changes that modify/break current functionality

None. The watchdog is disabled by default. When enabled, it only affects behavior if the agent becomes permanently unhealthy — previously the process would hang silently; now it restarts.

## Have you included tests for your changes?

Yes — `pkg/health/health_test.go` covers: disabled supervisor, healthy state, unhealthy detection, and the `MQTTChecker`.

## Did you document any new/modified functionality?

The new env vars (`MG_AGENT_WATCHDOG_INTERVAL`, `MG_AGENT_WATCHDOG_TIMEOUT`) are self-documenting. The supervisor logs health state transitions and systemd watchdog integration.
