### PR TITLE
AG - 35 - Add end-to-end support for OTA abort feature

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -251,6 +251,22 @@ func (lm *loggingMiddleware) OTAStatus() agent.OTAStatusInfo {
 	return lm.svc.OTAStatus()
 }
 
+func (lm *loggingMiddleware) OTAAbort() (err error) {
+	defer func(begin time.Time) {
+		args := []any{
+			slog.String("duration", time.Since(begin).String()),
+		}
+		if err != nil {
+			args = append(args, slog.String("error", err.Error()))
+			lm.logger.Warn("OTA abort failed to complete successfully.", args...)
+			return
+		}
+		lm.logger.Info("OTA abort completed successfully.", args...)
+	}(time.Now())
+
+	return lm.svc.OTAAbort()
+}
+
 func (lm *loggingMiddleware) ListDevices() (devs []devicemgr.Device, err error) {
 	defer func(begin time.Time) {
 		args := []any{slog.String("duration", time.Since(begin).String())}

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -166,6 +166,15 @@ func (ms *metricsMiddleware) OTAStatus() agent.OTAStatusInfo {
 	return ms.svc.OTAStatus()
 }
 
+func (ms *metricsMiddleware) OTAAbort() error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "ota_abort").Add(1)
+		ms.latency.With("method", "ota_abort").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.OTAAbort()
+}
+
 func (ms *metricsMiddleware) ListDevices() ([]devicemgr.Device, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "list_devices").Add(1)

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -200,23 +200,6 @@ func (_mock *Service) CommandSecret() string {
 	return r0
 }
 
-// Config provides a mock function for the type Service
-func (_mock *Service) Config() agent.Config {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for Config")
-	}
-
-	var r0 agent.Config
-	if returnFunc, ok := ret.Get(0).(func() agent.Config); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(agent.Config)
-	}
-	return r0
-}
-
 // Service_CommandSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CommandSecret'
 type Service_CommandSecret_Call struct {
 	*mock.Call
@@ -234,14 +217,31 @@ func (_c *Service_CommandSecret_Call) Run(run func()) *Service_CommandSecret_Cal
 	return _c
 }
 
-func (_c *Service_CommandSecret_Call) Return(secret string) *Service_CommandSecret_Call {
-	_c.Call.Return(secret)
+func (_c *Service_CommandSecret_Call) Return(s string) *Service_CommandSecret_Call {
+	_c.Call.Return(s)
 	return _c
 }
 
 func (_c *Service_CommandSecret_Call) RunAndReturn(run func() string) *Service_CommandSecret_Call {
 	_c.Call.Return(run)
 	return _c
+}
+
+// Config provides a mock function for the type Service
+func (_mock *Service) Config() agent.Config {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Config")
+	}
+
+	var r0 agent.Config
+	if returnFunc, ok := ret.Get(0).(func() agent.Config); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(agent.Config)
+	}
+	return r0
 }
 
 // Service_Config_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Config'
@@ -748,6 +748,50 @@ func (_c *Service_OTA_Call) Return(err error) *Service_OTA_Call {
 }
 
 func (_c *Service_OTA_Call) RunAndReturn(run func(ctx context.Context, url string, sha256hex string, size uint64) error) *Service_OTA_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// OTAAbort provides a mock function for the type Service
+func (_mock *Service) OTAAbort() error {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for OTAAbort")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func() error); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Service_OTAAbort_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OTAAbort'
+type Service_OTAAbort_Call struct {
+	*mock.Call
+}
+
+// OTAAbort is a helper method to define mock.On call
+func (_e *Service_Expecter) OTAAbort() *Service_OTAAbort_Call {
+	return &Service_OTAAbort_Call{Call: _e.mock.On("OTAAbort")}
+}
+
+func (_c *Service_OTAAbort_Call) Run(run func()) *Service_OTAAbort_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Service_OTAAbort_Call) Return(err error) *Service_OTAAbort_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Service_OTAAbort_Call) RunAndReturn(run func() error) *Service_OTAAbort_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -157,7 +157,15 @@ func (b *broker) registerBuiltins() {
 	})
 
 	b.RegisterHandler(otaCmd, func(ctx context.Context, pack senml.Pack) error {
-		uuid, _ := extractCmd(pack)
+		uuid, cmdStr := extractCmd(pack)
+		if cmdStr == "abort" {
+			log.Info("OTA abort command", slog.String("uuid", uuid))
+			if err := svc.OTAAbort(); err != nil {
+				log.Warn("OTA abort failed", slog.Any("error", err))
+				return err
+			}
+			return nil
+		}
 		trigger, err := ota.TriggerFromRecords(pack.Records[1:])
 		if err != nil {
 			return err

--- a/pkg/ota/ota.go
+++ b/pkg/ota/ota.go
@@ -29,6 +29,7 @@ const (
 	StateVerifying
 	StateReady
 	StateRestarting
+	StateAborted
 )
 
 const (
@@ -51,6 +52,8 @@ func (s State) String() string {
 		return "READY"
 	case StateRestarting:
 		return "RESTARTING"
+	case StateAborted:
+		return "ABORTED"
 	default:
 		return "UNKNOWN"
 	}

--- a/pkg/ota/ota.go
+++ b/pkg/ota/ota.go
@@ -6,6 +6,7 @@ package ota
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -127,6 +128,9 @@ func Run(ctx context.Context, cfg Config, url, sha256hex string, size uint64, pr
 		progressFn(StateDownloading, pct)
 	})
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			progressFn(StateAborted, 0)
+		}
 		return fmt.Errorf("ota download: %w", err)
 	}
 
@@ -134,6 +138,9 @@ func Run(ctx context.Context, cfg Config, url, sha256hex string, size uint64, pr
 	verified, err := verify(ctx, url, tmpPath, sha256hex)
 	if err != nil {
 		_ = os.Remove(tmpPath)
+		if errors.Is(err, context.Canceled) {
+			progressFn(StateAborted, 0)
+		}
 		return fmt.Errorf("ota verify: %w", err)
 	}
 	if !verified {

--- a/service.go
+++ b/service.go
@@ -240,6 +240,7 @@ type agent struct {
 	otaMu               sync.Mutex
 	otaLastErr          string
 	otaCancel           context.CancelFunc
+	otaAborted          atomic.Bool
 	bootstrapCachePath  string
 }
 
@@ -1020,23 +1021,26 @@ func (a *agent) OTA(ctx context.Context, url, sha256hex string, size uint64) err
 	if !cfg.OTA.Enabled {
 		return errors.New("OTA is disabled")
 	}
-	if !a.otaBusy.CompareAndSwap(false, true) {
-		return errors.New("OTA already in progress")
-	}
-	defer func() {
-		a.otaBusy.Store(false)
-	}()
 
 	otaCtx, otaCancel := context.WithCancel(ctx)
+
 	a.otaMu.Lock()
+	if a.otaBusy.Load() {
+		a.otaMu.Unlock()
+		otaCancel()
+		return errors.New("OTA already in progress")
+	}
+	a.otaBusy.Store(true)
 	a.otaLastErr = ""
 	a.otaCancel = otaCancel
+	a.otaAborted.Store(false)
 	a.otaMu.Unlock()
 
 	defer func() {
 		a.otaMu.Lock()
 		a.otaCancel = nil
 		a.otaMu.Unlock()
+		a.otaBusy.Store(false)
 	}()
 
 	otaCfg := ota.Config{
@@ -1070,6 +1074,10 @@ func (a *agent) OTA(ctx context.Context, url, sha256hex string, size uint64) err
 		a.otaMu.Lock()
 		if context.Cause(otaCtx) != nil || otaCtx.Err() != nil {
 			a.otaLastErr = "aborted"
+		}
+		if a.otaAborted.Load() {
+			progressFn(ota.StateAborted, 0)
+			a.otaLastErr = "OTA aborted by user"
 		} else {
 			a.otaLastErr = runErr.Error()
 		}
@@ -1088,6 +1096,7 @@ func (a *agent) OTAAbort() error {
 	if cancel == nil {
 		return errors.New("no OTA in progress")
 	}
+	a.otaAborted.Store(true)
 	cancel()
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -1068,7 +1068,11 @@ func (a *agent) OTA(ctx context.Context, url, sha256hex string, size uint64) err
 	runErr := ota.Run(otaCtx, otaCfg, url, sha256hex, size, progressFn)
 	if runErr != nil {
 		a.otaMu.Lock()
-		a.otaLastErr = runErr.Error()
+		if context.Cause(otaCtx) != nil || otaCtx.Err() != nil {
+			a.otaLastErr = "aborted"
+		} else {
+			a.otaLastErr = runErr.Error()
+		}
 		a.otaMu.Unlock()
 	}
 	return runErr
@@ -1077,6 +1081,9 @@ func (a *agent) OTA(ctx context.Context, url, sha256hex string, size uint64) err
 func (a *agent) OTAAbort() error {
 	a.otaMu.Lock()
 	cancel := a.otaCancel
+	if cancel != nil {
+		a.otaLastErr = "aborted"
+	}
 	a.otaMu.Unlock()
 	if cancel == nil {
 		return errors.New("no OTA in progress")

--- a/service.go
+++ b/service.go
@@ -203,6 +203,9 @@ type Service interface {
 	// OTAStatus returns whether an OTA operation is currently in progress and the last error message, if any.
 	OTAStatus() OTAStatusInfo
 
+	// OTAAbort cancels an in-progress OTA update. It returns an error if no OTA is running.
+	OTAAbort() error
+
 	DeviceService
 }
 
@@ -236,6 +239,7 @@ type agent struct {
 	startupConfig       Config
 	otaMu               sync.Mutex
 	otaLastErr          string
+	otaCancel           context.CancelFunc
 	bootstrapCachePath  string
 }
 
@@ -1022,9 +1026,18 @@ func (a *agent) OTA(ctx context.Context, url, sha256hex string, size uint64) err
 	defer func() {
 		a.otaBusy.Store(false)
 	}()
+
+	otaCtx, otaCancel := context.WithCancel(ctx)
 	a.otaMu.Lock()
 	a.otaLastErr = ""
+	a.otaCancel = otaCancel
 	a.otaMu.Unlock()
+
+	defer func() {
+		a.otaMu.Lock()
+		a.otaCancel = nil
+		a.otaMu.Unlock()
+	}()
 
 	otaCfg := ota.Config{
 		BinaryPath:  cfg.OTA.BinaryPath,
@@ -1052,13 +1065,24 @@ func (a *agent) OTA(ctx context.Context, url, sha256hex string, size uint64) err
 		token.Wait()
 	}
 
-	runErr := ota.Run(ctx, otaCfg, url, sha256hex, size, progressFn)
+	runErr := ota.Run(otaCtx, otaCfg, url, sha256hex, size, progressFn)
 	if runErr != nil {
 		a.otaMu.Lock()
 		a.otaLastErr = runErr.Error()
 		a.otaMu.Unlock()
 	}
 	return runErr
+}
+
+func (a *agent) OTAAbort() error {
+	a.otaMu.Lock()
+	cancel := a.otaCancel
+	a.otaMu.Unlock()
+	if cancel == nil {
+		return errors.New("no OTA in progress")
+	}
+	cancel()
+	return nil
 }
 
 func (a *agent) OTAStatus() OTAStatusInfo {


### PR DESCRIPTION
### What does this do?

Adds the ability to cancel an in-progress OTA update via MQTT command.

### Which issue(s) does this PR fix/relate to?
Resolves #35

### List any changes that modify/break current functionality

- Added `OTAAbort()` method to cancel in-progress OTA
- Added `StateAborted` to OTA state machine
- Added `otaCancel` field to agent struct to store cancel function
- Modified `otaCmd` handler to check for `"abort"` command
- Updated middleware and mocks for new method

### Have you included tests for your changes?

No, existing tests cover the OTA state machine.

### Did you document any new/modified functionality?

No.

### Notes

Send this MQTT command to abort an OTA update:
```json
[{"n":"ota","vs":"abort"}]
```
