### PR TITLE
AG-81 - Enhance Command Registry with Extensible Dispatch System

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Per-feature documentation with configuration, MQTT topic maps, and copy-paste te
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | [heartbeat.md](heartbeat.md) | Self-heartbeat and service liveness tracking, interval configuration, test recipes                          |
 | [telemetry.md](telemetry.md) | Periodic uptime telemetry, payload format, runtime configuration, test recipes                              |
-| [control.md](control.md)     | Command dispatch, runtime config get/set/reset, token authentication, exec subsystem, test recipes          |
+| [control.md](control.md)     | Command dispatch registry, agent lifecycle (stop/start/reload/status), runtime config, token auth, exec, route, help |
 | [bootstrap.md](bootstrap.md) | Profile-based provisioning flow, environment variables, cache management, test recipes                      |
 | [ota.md](ota.md)             | Over-the-air binary updates, trigger payload, download/verify/replace cycle, status reporting, test recipes |
 | [terminal.md](terminal.md)   | Interactive terminal sessions over MQTT, session lifecycle, PTY management, test recipes                    |

--- a/docs/control.md
+++ b/docs/control.md
@@ -8,18 +8,24 @@ All commands are sent as [SenML][senml] JSON arrays to the **commands channel re
 
 ### Command Subsystems
 
+The dispatch registry is extensible — handlers can be registered at runtime — and each command carries metadata (description, usage) surfaced by the `help` command.
+
 | `n` value | Handler       | Description                                                     |
 | --------- | ------------- | --------------------------------------------------------------- |
 | `exec`    | Execute       | Run an allowlisted shell command                                |
 | `config`  | ServiceConfig | View services, get/set/reset runtime config, save export config |
 | `service` | ServiceConfig | Alias for `config` — same handler                               |
-| `control` | Control       | Node-RED management commands                                    |
+| `control` | Control       | Agent lifecycle (stop/start/reload/status) and Node-RED passthrough |
 | `term`    | Terminal      | Open/close/write interactive terminal sessions                  |
 | `nodered` | NodeRed       | Node-RED flow operations                                        |
 | `ping`    | Ping          | Publish an immediate heartbeat                                  |
 | `reset`   | Reset         | Graceful shutdown and process restart                           |
-| `ota`     | OTA           | Over-the-air binary update                                      |
+| `ota`     | OTA           | Over-the-air binary update (trigger/status/abort)              |
 | `devices` | DeviceManager | Downstream device CRUD                                          |
+| `route`   | Route         | Forward a payload to a downstream device interface              |
+| `help`    | —             | List available commands and their usage                         |
+
+Authorization is enforced **per command**: when a command secret is configured, each command that requires auth must carry a matching `token` record in the SenML pack (see [Token Authentication](#token-authentication)).
 
 ## Message Format
 
@@ -255,6 +261,47 @@ mosquitto_pub \
     -u <client-id> -P <client-secret> --id "cfg-$(date +%s)" \
     -t "m/<domain-id>/c/<commands-channel-id>/req" \
     -m "[{\"bn\":\"req-1:\", \"n\":\"config\", \"vs\":\"save,export,/path/to/config.toml,$CONTENT\"}]"
+```
+
+## Agent Lifecycle (control subsystem)
+
+The `control` command manages the running agent without restarting the process. `reset` (below) is used for a full process restart.
+
+| `vs`         | Behavior                                                                              | Response                              |
+| ------------ | ------------------------------------------------------------------------------------- | ------------------------------------- |
+| `stop`       | Pause the heartbeat, telemetry, and device-scheduler loops; the process stays alive   | `stopped`                             |
+| `start`      | Resume the paused loops and restart the device scheduler                              | `started`                             |
+| `reload`     | Re-apply persisted runtime config overrides (validated; invalid values are skipped)   | `reloaded` or `reloaded:<keys>`       |
+| `status`     | Report current runtime state                                                          | `{running, paused, uptime_seconds, version}` JSON |
+| `nodered-*`  | Node-RED passthrough (see [nodered.md](nodered.md))                                   | command-specific                      |
+
+```bash
+# Pause background publishing (agent stays alive), then resume
+mosquitto_pub ... -m '[{"bn":"req-1:","n":"control","vs":"stop"}]'
+mosquitto_pub ... -m '[{"bn":"req-1:","n":"control","vs":"start"}]'
+
+# Re-apply persisted overrides and report status
+mosquitto_pub ... -m '[{"bn":"req-1:","n":"control","vs":"reload"}]'
+mosquitto_pub ... -m '[{"bn":"req-1:","n":"control","vs":"status"}]'
+```
+
+## Route to Downstream Device
+
+The `route` command forwards a hex payload to a registered device's physical interface (opening it if needed), then optionally reads back `<read_bytes>` and returns them as a hex string. With no `read_bytes`, the number of bytes written is returned.
+
+```bash
+# Write bytes 01 a2 ff to <device-id> and read 16 bytes back
+mosquitto_pub ... -m '[{"bn":"req-1:","n":"route","vs":"<device-id>,01a2ff,16"}]'
+```
+
+A missing device returns a clear "device not found" error. See [devices.md](devices.md) for device provisioning.
+
+## Discover Commands (help)
+
+The `help` command returns the registry as a JSON array of `{name, description, usage}`:
+
+```bash
+mosquitto_pub ... -m '[{"bn":"req-1:","n":"help","vs":""}]'
 ```
 
 ## Reset (process restart)

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -38,6 +38,8 @@ All device commands are sent via the `devices` dispatch name on the commands cha
 | `read`     | `devices,read,<device_id>,<n_bytes>`                                                                    | Read n bytes from device, reply as hex string |
 | `write`    | `devices,write,<device_id>,<hex_data>`                                                                  | Write hex-encoded bytes to the device         |
 
+> For a single write-then-read round trip to a device, the [`route`](control.md#route-to-downstream-device) command (`route,<device_id>,<hex_payload>[,<read_bytes>]`) opens the interface if needed, writes the payload, and returns the response in one command.
+
 ## Provisioning Flow
 
 When `add` is called, the agent:

--- a/docs/ota.md
+++ b/docs/ota.md
@@ -146,6 +146,18 @@ mosquitto_pub \
     -m '[{"bn":"req-1:","n":"ota","vs":"abort"}]'
 ```
 
+### Query OTA status via commands channel
+
+Returns the current OTA state (`busy` and `last_error`) as a JSON response on the control response topic:
+
+```bash
+mosquitto_pub \
+    -h <mqtt-host> -p 1883 \
+    -u <client-id> -P <client-secret> --id "ota-$(date +%s)" \
+    -t "m/<domain-id>/c/<commands-channel-id>/req" \
+    -m '[{"bn":"req-1:","n":"ota","vs":"status"}]'
+```
+
 ### Trigger OTA with token auth (when command_secret is set)
 
 ```bash

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -96,6 +96,24 @@ func (lm *loggingMiddleware) Control(uuid, cmd string) (err error) {
 	return lm.svc.Control(uuid, cmd)
 }
 
+func (lm *loggingMiddleware) Route(ctx context.Context, uuid, cmd string) (err error) {
+	defer func(begin time.Time) {
+		args := []any{
+			slog.String("duration", time.Since(begin).String()),
+			slog.String("uuid", uuid),
+			slog.String("cmd", cmd),
+		}
+		if err != nil {
+			args = append(args, slog.String("error", err.Error()))
+			lm.logger.Warn("Route command failed to complete successfully.", args...)
+			return
+		}
+		lm.logger.Info("Route command completed successfully.", args...)
+	}(time.Now())
+
+	return lm.svc.Route(ctx, uuid, cmd)
+}
+
 func (lm *loggingMiddleware) AddConfig(c agent.Config) (err error) {
 	defer func(begin time.Time) {
 		args := []any{

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -59,6 +59,15 @@ func (ms *metricsMiddleware) Control(uuid, cmdStr string) error {
 	return ms.svc.Control(uuid, cmdStr)
 }
 
+func (ms *metricsMiddleware) Route(ctx context.Context, uuid, cmdStr string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "route").Add(1)
+		ms.latency.With("method", "route").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.Route(ctx, uuid, cmdStr)
+}
+
 func (ms *metricsMiddleware) AddConfig(ec agent.Config) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "add_config").Add(1)

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -884,63 +884,6 @@ func (_c *Service_Ping_Call) RunAndReturn(run func() error) *Service_Ping_Call {
 	return _c
 }
 
-// Reset provides a mock function for the type Service
-func (_mock *Service) Reset(ctx context.Context, mode string) error {
-	ret := _mock.Called(ctx, mode)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Reset")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = returnFunc(ctx, mode)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// Service_Reset_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reset'
-type Service_Reset_Call struct {
-	*mock.Call
-}
-
-// Reset is a helper method to define mock.On call
-//   - ctx context.Context
-//   - mode string
-func (_e *Service_Expecter) Reset(ctx interface{}, mode interface{}) *Service_Reset_Call {
-	return &Service_Reset_Call{Call: _e.mock.On("Reset", ctx, mode)}
-}
-
-func (_c *Service_Reset_Call) Run(run func(ctx context.Context, mode string)) *Service_Reset_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *Service_Reset_Call) Return(err error) *Service_Reset_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *Service_Reset_Call) RunAndReturn(run func(ctx context.Context, mode string) error) *Service_Reset_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Publish provides a mock function for the type Service
 func (_mock *Service) Publish(topic string, payload string) error {
 	ret := _mock.Called(topic, payload)
@@ -1045,6 +988,126 @@ func (_c *Service_RemoveDevice_Call) Return(err error) *Service_RemoveDevice_Cal
 }
 
 func (_c *Service_RemoveDevice_Call) RunAndReturn(run func(id string) error) *Service_RemoveDevice_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Reset provides a mock function for the type Service
+func (_mock *Service) Reset(ctx context.Context, mode string) error {
+	ret := _mock.Called(ctx, mode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reset")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, mode)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Service_Reset_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reset'
+type Service_Reset_Call struct {
+	*mock.Call
+}
+
+// Reset is a helper method to define mock.On call
+//   - ctx context.Context
+//   - mode string
+func (_e *Service_Expecter) Reset(ctx interface{}, mode interface{}) *Service_Reset_Call {
+	return &Service_Reset_Call{Call: _e.mock.On("Reset", ctx, mode)}
+}
+
+func (_c *Service_Reset_Call) Run(run func(ctx context.Context, mode string)) *Service_Reset_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Service_Reset_Call) Return(err error) *Service_Reset_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Service_Reset_Call) RunAndReturn(run func(ctx context.Context, mode string) error) *Service_Reset_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Route provides a mock function for the type Service
+func (_mock *Service) Route(ctx context.Context, uuid string, cmdStr string) error {
+	ret := _mock.Called(ctx, uuid, cmdStr)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Route")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, uuid, cmdStr)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Service_Route_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Route'
+type Service_Route_Call struct {
+	*mock.Call
+}
+
+// Route is a helper method to define mock.On call
+//   - ctx context.Context
+//   - uuid string
+//   - cmdStr string
+func (_e *Service_Expecter) Route(ctx interface{}, uuid interface{}, cmdStr interface{}) *Service_Route_Call {
+	return &Service_Route_Call{Call: _e.mock.On("Route", ctx, uuid, cmdStr)}
+}
+
+func (_c *Service_Route_Call) Run(run func(ctx context.Context, uuid string, cmdStr string)) *Service_Route_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *Service_Route_Call) Return(err error) *Service_Route_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Service_Route_Call) RunAndReturn(run func(ctx context.Context, uuid string, cmdStr string) error) *Service_Route_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -6,10 +6,12 @@ package conn
 import (
 	"context"
 	"crypto/subtle"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -37,6 +39,11 @@ const (
 	reset   = "reset"
 	otaCmd  = "ota"
 	devices = "devices"
+	route   = "route"
+	help    = "help"
+
+	otaStatus = "status"
+	otaAbort  = "abort"
 )
 
 var channelPartRegExp = regexp.MustCompile(`^m/([\w\-]+)/c/([\w\-]+)/services(/[^?]*)?(\?.*)?$`)
@@ -45,6 +52,24 @@ var channelPartRegExp = regexp.MustCompile(`^m/([\w\-]+)/c/([\w\-]+)/services(/[
 // pack contains the full decoded SenML pack; pack.Records[0] is always the
 // command record. Multi-record commands (e.g. OTA) use pack.Records[1:].
 type CommandHandler func(ctx context.Context, pack senml.Pack) error
+
+// Command describes a registered command together with its handler and
+// human-readable metadata. The metadata is surfaced by the built-in help
+// command so operators can discover the available command surface at runtime.
+type Command struct {
+	// Name is the SenML record name that selects this command.
+	Name string
+	// Description is a one-line summary of what the command does.
+	Description string
+	// Usage documents the argument format, e.g. "exec,<command>[,arg...]".
+	Usage string
+	// Handler processes the decoded command pack.
+	Handler CommandHandler
+	// RequiresAuth, when true, rejects the command if a command secret is
+	// configured and the pack lacks a valid token. Authorization is therefore
+	// enforced per command rather than as a single global gate.
+	RequiresAuth bool
+}
 
 var _ MqttBroker = (*broker)(nil)
 
@@ -56,7 +81,13 @@ type MqttBroker interface {
 	Resubscribe()
 	// RegisterHandler registers a CommandHandler for the given command name.
 	// Calling RegisterHandler with an existing name replaces the previous handler.
+	// The command is registered with RequiresAuth set to true.
 	RegisterHandler(name string, h CommandHandler)
+	// Register adds a Command (with metadata) to the registry, replacing any
+	// existing command registered under the same name.
+	Register(cmd Command)
+	// Commands returns all registered commands sorted by name.
+	Commands() []Command
 }
 
 type broker struct {
@@ -66,7 +97,7 @@ type broker struct {
 	channel  string
 	domainID string
 	ctx      context.Context
-	handlers map[string]CommandHandler
+	commands map[string]Command
 	mu       sync.RWMutex
 }
 
@@ -79,7 +110,7 @@ func NewBroker(svc agent.Service, client mqtt.Client, chann, domainID string, lo
 		logger:   log,
 		channel:  chann,
 		domainID: domainID,
-		handlers: make(map[string]CommandHandler),
+		commands: make(map[string]Command),
 	}
 	b.registerBuiltins()
 	return b
@@ -87,137 +118,300 @@ func NewBroker(svc agent.Service, client mqtt.Client, chann, domainID string, lo
 
 // RegisterHandler registers a CommandHandler for name, replacing any existing one.
 // A nil handler is rejected to avoid panics when a matching command arrives later.
+// The command is registered with RequiresAuth set to true.
 func (b *broker) RegisterHandler(name string, h CommandHandler) {
 	if h == nil {
 		b.logger.Warn("RegisterHandler called with nil handler", slog.String("name", name))
 		return
 	}
+	b.Register(Command{Name: name, Handler: h, RequiresAuth: true})
+}
+
+// Register adds cmd to the registry, replacing any existing command with the
+// same name. A command with a nil handler or empty name is rejected.
+func (b *broker) Register(cmd Command) {
+	if cmd.Handler == nil {
+		b.logger.Warn("Register called with nil handler", slog.String("name", cmd.Name))
+		return
+	}
+	if cmd.Name == "" {
+		b.logger.Warn("Register called with empty command name")
+		return
+	}
 	b.mu.Lock()
-	b.handlers[name] = h
+	b.commands[cmd.Name] = cmd
 	b.mu.Unlock()
 }
 
-// registerBuiltins wires the built-in command set into the handler registry.
+// Commands returns all registered commands sorted by name.
+func (b *broker) Commands() []Command {
+	b.mu.RLock()
+	out := make([]Command, 0, len(b.commands))
+	for _, c := range b.commands {
+		out = append(out, c)
+	}
+	b.mu.RUnlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// registerBuiltins wires the built-in command set into the command registry.
+// Every built-in declares RequiresAuth: true, preserving the requirement that
+// commands carry a valid token whenever a command secret is configured.
 func (b *broker) registerBuiltins() {
 	svc := b.svc
 	log := b.logger
 
-	b.RegisterHandler(control, func(ctx context.Context, pack senml.Pack) error {
-		uuid, cmdStr := extractCmd(pack)
-		log.Info("Control command", slog.String("uuid", uuid), slog.String("command", cmdStr))
-		return svc.Control(uuid, cmdStr)
+	b.Register(Command{
+		Name:         control,
+		Description:  "Agent lifecycle control and Node-RED passthrough",
+		Usage:        "control,<stop|start|reload|status|nodered-*>",
+		RequiresAuth: true,
+		Handler: func(_ context.Context, pack senml.Pack) error {
+			uuid, cmdStr := extractCmd(pack)
+			log.Info("Control command", slog.String("uuid", uuid), slog.String("command", cmdStr))
+			return svc.Control(uuid, cmdStr)
+		},
 	})
 
-	b.RegisterHandler(exec, func(ctx context.Context, pack senml.Pack) error {
-		uuid, cmdStr := extractCmd(pack)
-		log.Info("Execute command", slog.String("uuid", uuid), slog.String("command", cmdStr))
-		_, err := svc.Execute(uuid, cmdStr)
-		return err
+	b.Register(Command{
+		Name:         exec,
+		Description:  "Execute an allowlisted shell command",
+		Usage:        "exec,<command>[,arg...]",
+		RequiresAuth: true,
+		Handler: func(_ context.Context, pack senml.Pack) error {
+			uuid, cmdStr := extractCmd(pack)
+			log.Info("Execute command", slog.String("uuid", uuid), slog.String("command", cmdStr))
+			_, err := svc.Execute(uuid, cmdStr)
+			return err
+		},
 	})
 
-	b.RegisterHandler(config, func(ctx context.Context, pack senml.Pack) error {
-		uuid, cmdStr := extractCmd(pack)
-		log.Info("Config command", slog.String("uuid", uuid), slog.String("command", cmdStr))
-		return svc.ServiceConfig(ctx, uuid, cmdStr)
+	b.Register(Command{
+		Name:         config,
+		Description:  "View or modify runtime configuration",
+		Usage:        "config,<view|get|set|save|reset>[,args...]",
+		RequiresAuth: true,
+		Handler: func(ctx context.Context, pack senml.Pack) error {
+			uuid, cmdStr := extractCmd(pack)
+			log.Info("Config command", slog.String("uuid", uuid), slog.String("command", cmdStr))
+			return svc.ServiceConfig(ctx, uuid, cmdStr)
+		},
 	})
 
-	b.RegisterHandler(service, func(ctx context.Context, pack senml.Pack) error {
-		uuid, cmdStr := extractCmd(pack)
-		log.Info("Services view command", slog.String("uuid", uuid), slog.String("command", cmdStr))
-		return svc.ServiceConfig(ctx, uuid, cmdStr)
+	b.Register(Command{
+		Name:         service,
+		Description:  "View registered local services",
+		Usage:        "service,view",
+		RequiresAuth: true,
+		Handler: func(ctx context.Context, pack senml.Pack) error {
+			uuid, cmdStr := extractCmd(pack)
+			log.Info("Services view command", slog.String("uuid", uuid), slog.String("command", cmdStr))
+			return svc.ServiceConfig(ctx, uuid, cmdStr)
+		},
 	})
 
-	b.RegisterHandler(term, func(ctx context.Context, pack senml.Pack) error {
-		uuid, cmdStr := extractCmd(pack)
-		log.Info("Term command", slog.String("uuid", uuid), slog.String("command", cmdStr))
-		return svc.Terminal(uuid, cmdStr)
+	b.Register(Command{
+		Name:         term,
+		Description:  "Interactive terminal session control",
+		Usage:        "term,<base64(open|close|c,<data>)>",
+		RequiresAuth: true,
+		Handler: func(_ context.Context, pack senml.Pack) error {
+			uuid, cmdStr := extractCmd(pack)
+			log.Info("Term command", slog.String("uuid", uuid), slog.String("command", cmdStr))
+			return svc.Terminal(uuid, cmdStr)
+		},
 	})
 
-	b.RegisterHandler(nred, func(ctx context.Context, pack senml.Pack) error {
-		uuid, cmdStr := extractCmd(pack)
-		log.Info("NodeRed command", slog.String("uuid", uuid), slog.String("command", cmdStr))
-		resp, err := svc.NodeRed(cmdStr)
-		if err != nil {
-			if payload, encErr := encoder.EncodeSenML(uuid, nred, err.Error()); encErr == nil {
-				if pubErr := svc.Publish("control", string(payload)); pubErr != nil {
-					log.Warn("Failed to publish NodeRed error response", slog.Any("error", pubErr))
+	b.Register(Command{
+		Name:         nred,
+		Description:  "Node-RED flow management",
+		Usage:        "nodered,<nodered-deploy|nodered-add-flow|nodered-flows|nodered-state|nodered-ping>[,<base64-flow>]",
+		RequiresAuth: true,
+		Handler: func(_ context.Context, pack senml.Pack) error {
+			uuid, cmdStr := extractCmd(pack)
+			log.Info("NodeRed command", slog.String("uuid", uuid), slog.String("command", cmdStr))
+			resp, err := svc.NodeRed(cmdStr)
+			if err != nil {
+				if payload, encErr := encoder.EncodeSenML(uuid, nred, err.Error()); encErr == nil {
+					if pubErr := svc.Publish(control, string(payload)); pubErr != nil {
+						log.Warn("Failed to publish NodeRed error response", slog.Any("error", pubErr))
+					}
 				}
-			}
-			return err
-		}
-		if payload, encErr := encoder.EncodeSenML(uuid, nred, resp); encErr == nil {
-			if pubErr := svc.Publish("control", string(payload)); pubErr != nil {
-				log.Warn("Failed to publish NodeRed response", slog.Any("error", pubErr))
-			}
-		}
-		return nil
-	})
-
-	b.RegisterHandler(ping, func(ctx context.Context, pack senml.Pack) error {
-		log.Info("Ping command")
-		return svc.Ping()
-	})
-
-	b.RegisterHandler(reset, func(ctx context.Context, pack senml.Pack) error {
-		uuid, cmdStr := extractCmd(pack)
-		mode := agent.ResetGraceful
-		if cmdStr != "" {
-			mode = cmdStr
-		}
-		log.Info("Reset command received", slog.String("uuid", uuid), slog.String("mode", mode))
-		if err := svc.Reset(ctx, mode); err != nil {
-			log.Error("Reset failed", slog.Any("error", err))
-			return err
-		}
-		switch mode {
-		case agent.ResetGraceful, agent.ResetImmediate, agent.ResetNow:
-			log.Info("Re-executing agent binary", slog.String("mode", mode))
-			if err := syscall.Exec(os.Args[0], os.Args, os.Environ()); err != nil {
-				log.Error("Re-exec failed", slog.Any("error", err))
 				return err
 			}
-		case agent.ResetWatchdog:
-			log.Info("Watchdog reset delegated to health supervisor")
-		}
-		return nil
+			if payload, encErr := encoder.EncodeSenML(uuid, nred, resp); encErr == nil {
+				if pubErr := svc.Publish(control, string(payload)); pubErr != nil {
+					log.Warn("Failed to publish NodeRed response", slog.Any("error", pubErr))
+				}
+			}
+			return nil
+		},
 	})
 
-	b.RegisterHandler(otaCmd, func(ctx context.Context, pack senml.Pack) error {
-		uuid, cmdStr := extractCmd(pack)
-		if cmdStr == "abort" {
-			log.Info("OTA abort command", slog.String("uuid", uuid))
-			if err := svc.OTAAbort(); err != nil {
-				log.Warn("OTA abort failed", slog.Any("error", err))
+	b.Register(Command{
+		Name:         ping,
+		Description:  "Publish an immediate health heartbeat",
+		Usage:        "ping",
+		RequiresAuth: true,
+		Handler: func(_ context.Context, _ senml.Pack) error {
+			log.Info("Ping command")
+			return svc.Ping()
+		},
+	})
+
+	b.Register(Command{
+		Name:         reset,
+		Description:  "Reboot/reset the agent process",
+		Usage:        "reset,<graceful|immediate|watchdog|now>",
+		RequiresAuth: true,
+		Handler: func(ctx context.Context, pack senml.Pack) error {
+			uuid, cmdStr := extractCmd(pack)
+			mode := agent.ResetGraceful
+			if cmdStr != "" {
+				mode = cmdStr
+			}
+			log.Info("Reset command received", slog.String("uuid", uuid), slog.String("mode", mode))
+			if err := svc.Reset(ctx, mode); err != nil {
+				log.Error("Reset failed", slog.Any("error", err))
+				return err
+			}
+			switch mode {
+			case agent.ResetGraceful, agent.ResetImmediate, agent.ResetNow:
+				log.Info("Re-executing agent binary", slog.String("mode", mode))
+				if err := syscall.Exec(os.Args[0], os.Args, os.Environ()); err != nil {
+					log.Error("Re-exec failed", slog.Any("error", err))
+					return err
+				}
+			case agent.ResetWatchdog:
+				log.Info("Watchdog reset delegated to health supervisor")
+			}
+			return nil
+		},
+	})
+
+	b.Register(Command{
+		Name:         otaCmd,
+		Description:  "Trigger, query, or abort an OTA update",
+		Usage:        "ota,<status|abort> | ota with url/hash/size records",
+		RequiresAuth: true,
+		Handler: func(ctx context.Context, pack senml.Pack) error {
+			uuid, cmdStr := extractCmd(pack)
+			switch cmdStr {
+			case otaAbort:
+				log.Info("OTA abort command", slog.String("uuid", uuid))
+				if err := svc.OTAAbort(); err != nil {
+					log.Warn("OTA abort failed", slog.Any("error", err))
+					return err
+				}
+				return nil
+			case otaStatus:
+				log.Info("OTA status command", slog.String("uuid", uuid))
+				return b.publishOTAStatus(uuid)
+			}
+			trigger, err := ota.TriggerFromRecords(pack.Records[1:])
+			if err != nil {
+				return err
+			}
+			log.Info("OTA command", slog.String("uuid", uuid), slog.String("url", trigger.URL))
+			go func() {
+				if err := svc.OTA(context.WithoutCancel(ctx), trigger.URL, trigger.SHA256Hex, trigger.Size); err != nil {
+					log.Warn("OTA operation failed", slog.Any("error", err))
+				}
+			}()
+			return nil
+		},
+	})
+
+	b.Register(Command{
+		Name:         devices,
+		Description:  "Manage downstream devices",
+		Usage:        "devices,<list|add|remove|get|seen|open|close|read|write>[,args...]",
+		RequiresAuth: true,
+		Handler: func(ctx context.Context, pack senml.Pack) error {
+			uuid, cmdStr := extractCmd(pack)
+			log.Info("Devices command", slog.String("uuid", uuid), slog.String("command", cmdStr))
+			if err := svc.DeviceManager(ctx, uuid, cmdStr); err != nil {
+				if payload, encErr := encoder.EncodeSenML(uuid, devices, err.Error()); encErr == nil {
+					if pubErr := svc.Publish(control, string(payload)); pubErr != nil {
+						log.Warn("Failed to publish DeviceManager error response", slog.Any("error", pubErr))
+					}
+				}
 				return err
 			}
 			return nil
-		}
-		trigger, err := ota.TriggerFromRecords(pack.Records[1:])
-		if err != nil {
-			return err
-		}
-		log.Info("OTA command", slog.String("uuid", uuid), slog.String("url", trigger.URL))
-		go func() {
-			if err := svc.OTA(context.WithoutCancel(ctx), trigger.URL, trigger.SHA256Hex, trigger.Size); err != nil {
-				log.Warn("OTA operation failed", slog.Any("error", err))
-			}
-		}()
-		return nil
+		},
 	})
 
-	b.handlers[devices] = func(ctx context.Context, pack senml.Pack) error {
-		uuid, cmdStr := extractCmd(pack)
-		log.Info("Devices command", slog.String("uuid", uuid), slog.String("command", cmdStr))
-		if err := svc.DeviceManager(ctx, uuid, cmdStr); err != nil {
-			if payload, encErr := encoder.EncodeSenML(uuid, devices, err.Error()); encErr == nil {
-				if pubErr := svc.Publish("control", string(payload)); pubErr != nil {
-					log.Warn("Failed to publish DeviceManager error response", slog.Any("error", pubErr))
+	b.Register(Command{
+		Name:         route,
+		Description:  "Forward a payload to a downstream device interface",
+		Usage:        "route,<device_id>,<hex_payload>[,<read_bytes>]",
+		RequiresAuth: true,
+		Handler: func(ctx context.Context, pack senml.Pack) error {
+			uuid, cmdStr := extractCmd(pack)
+			log.Info("Route command", slog.String("uuid", uuid), slog.String("command", cmdStr))
+			if err := svc.Route(ctx, uuid, cmdStr); err != nil {
+				if payload, encErr := encoder.EncodeSenML(uuid, route, err.Error()); encErr == nil {
+					if pubErr := svc.Publish(control, string(payload)); pubErr != nil {
+						log.Warn("Failed to publish Route error response", slog.Any("error", pubErr))
+					}
 				}
+				return err
 			}
-			return err
-		}
-		return nil
+			return nil
+		},
+	})
+
+	b.Register(Command{
+		Name:         help,
+		Description:  "List available commands and their usage",
+		Usage:        "help",
+		RequiresAuth: true,
+		Handler: func(_ context.Context, pack senml.Pack) error {
+			uuid, _ := extractCmd(pack)
+			log.Info("Help command", slog.String("uuid", uuid))
+			return b.publishHelp(uuid)
+		},
+	})
+}
+
+// publishHelp marshals the registered command metadata to JSON and publishes it
+// as the response to a help command.
+func (b *broker) publishHelp(uuid string) error {
+	type cmdInfo struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Usage       string `json:"usage"`
 	}
+	cmds := b.Commands()
+	infos := make([]cmdInfo, 0, len(cmds))
+	for _, c := range cmds {
+		infos = append(infos, cmdInfo{Name: c.Name, Description: c.Description, Usage: c.Usage})
+	}
+	j, err := json.Marshal(infos)
+	if err != nil {
+		return fmt.Errorf("help: marshal commands: %w", err)
+	}
+	payload, err := encoder.EncodeSenML(uuid, help, string(j))
+	if err != nil {
+		return fmt.Errorf("help: encode response: %w", err)
+	}
+	return b.svc.Publish(control, string(payload))
+}
+
+// publishOTAStatus marshals the current OTA status to JSON and publishes it as
+// the response to an ota,status command.
+func (b *broker) publishOTAStatus(uuid string) error {
+	j, err := json.Marshal(b.svc.OTAStatus())
+	if err != nil {
+		return fmt.Errorf("ota status: marshal: %w", err)
+	}
+	payload, err := encoder.EncodeSenML(uuid, otaCmd, string(j))
+	if err != nil {
+		return fmt.Errorf("ota status: encode response: %w", err)
+	}
+	return b.svc.Publish(control, string(payload))
 }
 
 // Subscribe subscribes to the MQTT message broker.
@@ -339,26 +533,30 @@ func (b *broker) handleMsg(msg mqtt.Message) {
 		return
 	}
 
-	commandSecret := b.svc.CommandSecret()
-	if commandSecret != "" {
-		if !authorizeCommand(records, commandSecret) {
-			b.logger.Warn("Command rejected: invalid or missing token")
-			return
-		}
-	}
-
 	cmdType := records[0].Name
 
 	b.mu.RLock()
-	h, ok := b.handlers[cmdType]
+	cmd, ok := b.commands[cmdType]
 	b.mu.RUnlock()
 
 	if !ok {
 		b.logger.Warn("no handler registered for command", slog.String("command", cmdType))
 		return
 	}
+
+	// Authorization is enforced per command: a command with RequiresAuth set is
+	// rejected unless it carries a valid token whenever a command secret is set.
+	if cmd.RequiresAuth {
+		if commandSecret := b.svc.CommandSecret(); commandSecret != "" {
+			if !authorizeCommand(records, commandSecret) {
+				b.logger.Warn("Command rejected: invalid or missing token", slog.String("command", cmdType))
+				return
+			}
+		}
+	}
+
 	sm := senml.Pack{Records: records}
-	if err := h(b.ctx, sm); err != nil {
+	if err := cmd.Handler(b.ctx, sm); err != nil {
 		b.logger.Warn("command handler failed", slog.String("command", cmdType), slog.Any("error", err))
 	}
 }

--- a/pkg/conn/registry_test.go
+++ b/pkg/conn/registry_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package conn
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/absmach/agent"
+	agentmocks "github.com/absmach/agent/mocks"
+	"github.com/absmach/agent/pkg/senml"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMessage is a minimal mqtt.Message used to drive handleMsg in tests.
+type fakeMessage struct {
+	topic   string
+	payload []byte
+}
+
+func (m fakeMessage) Duplicate() bool   { return false }
+func (m fakeMessage) Qos() byte         { return 0 }
+func (m fakeMessage) Retained() bool    { return false }
+func (m fakeMessage) Topic() string     { return m.topic }
+func (m fakeMessage) MessageID() uint16 { return 0 }
+func (m fakeMessage) Payload() []byte   { return m.payload }
+func (m fakeMessage) Ack()              {}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// newTestBroker builds a broker backed by mock service and client. The returned
+// concrete type lets tests exercise the unexported registry and dispatch paths.
+func newTestBroker(t *testing.T, svc *agentmocks.Service) *broker {
+	t.Helper()
+	client := agentmocks.NewMQTTClient(t)
+	b := NewBroker(svc, client, "ctrl-channel", "domain-1", discardLogger()).(*broker)
+	b.ctx = context.Background()
+	return b
+}
+
+func cmdPack(t *testing.T, uuid, name, value string, extra ...senml.Record) []byte {
+	t.Helper()
+	records := []senml.Record{{BaseName: uuid + ":", Name: name, StringValue: &value}}
+	records = append(records, extra...)
+	b, err := senml.EncodeRecords(records)
+	require.NoError(t, err)
+	return b
+}
+
+func TestBrokerRegistryMetadata(t *testing.T) {
+	svc := agentmocks.NewService(t)
+	b := newTestBroker(t, svc)
+
+	cmds := b.Commands()
+	byName := make(map[string]Command, len(cmds))
+	for _, c := range cmds {
+		byName[c.Name] = c
+	}
+
+	// Every command issued by the issue plus the registry helpers must exist.
+	for _, name := range []string{control, exec, config, service, term, nred, ping, reset, otaCmd, devices, route, help} {
+		c, ok := byName[name]
+		assert.Truef(t, ok, "command %q should be registered", name)
+		assert.NotEmptyf(t, c.Description, "command %q should have a description", name)
+		assert.NotEmptyf(t, c.Usage, "command %q should have usage docs", name)
+		assert.Truef(t, c.RequiresAuth, "built-in command %q should require auth", name)
+	}
+
+	// Commands() must be sorted by name.
+	for i := 1; i < len(cmds); i++ {
+		assert.LessOrEqual(t, cmds[i-1].Name, cmds[i].Name)
+	}
+}
+
+func TestBrokerRegister(t *testing.T) {
+	svc := agentmocks.NewService(t)
+	b := newTestBroker(t, svc)
+
+	before := len(b.Commands())
+
+	noop := func(context.Context, senml.Pack) error { return nil }
+
+	// A nil handler and an empty name are both rejected.
+	b.Register(Command{Name: "ignored-nil"})
+	b.Register(Command{Handler: noop})
+	assert.Len(t, b.Commands(), before, "invalid registrations must be ignored")
+
+	// A valid registration is added with its metadata preserved.
+	b.Register(Command{Name: "custom", Description: "d", Usage: "u", Handler: noop, RequiresAuth: false})
+	cmds := b.Commands()
+	assert.Len(t, cmds, before+1)
+
+	var custom Command
+	for _, c := range cmds {
+		if c.Name == "custom" {
+			custom = c
+		}
+	}
+	assert.Equal(t, "d", custom.Description)
+	assert.False(t, custom.RequiresAuth)
+
+	// RegisterHandler defaults RequiresAuth to true.
+	b.RegisterHandler("legacy", noop)
+	cmds = b.Commands()
+	var legacy Command
+	for _, c := range cmds {
+		if c.Name == "legacy" {
+			legacy = c
+		}
+	}
+	assert.True(t, legacy.RequiresAuth)
+}
+
+func TestHandleMsgPerCommandAuth(t *testing.T) {
+	const secret = "s3cr3t"
+
+	cases := []struct {
+		desc         string
+		requiresAuth bool
+		withToken    bool
+		wantInvoked  bool
+	}{
+		{desc: "no-auth command dispatches without token", requiresAuth: false, withToken: false, wantInvoked: true},
+		{desc: "auth command rejected without token", requiresAuth: true, withToken: false, wantInvoked: false},
+		{desc: "auth command dispatches with valid token", requiresAuth: true, withToken: true, wantInvoked: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			svc := agentmocks.NewService(t)
+			// CommandSecret is consulted only for RequiresAuth commands.
+			svc.EXPECT().CommandSecret().Return(secret).Maybe()
+			b := newTestBroker(t, svc)
+
+			invoked := false
+			b.Register(Command{
+				Name:         "probe",
+				Description:  "test probe",
+				Usage:        "probe",
+				RequiresAuth: tc.requiresAuth,
+				Handler: func(context.Context, senml.Pack) error {
+					invoked = true
+					return nil
+				},
+			})
+
+			var extra []senml.Record
+			if tc.withToken {
+				extra = append(extra, senml.Record{Name: "token", StringValue: new(secret)})
+			}
+			b.handleMsg(fakeMessage{payload: cmdPack(t, "u1", "probe", "", extra...)})
+
+			assert.Equal(t, tc.wantInvoked, invoked)
+		})
+	}
+}
+
+func TestHandleMsgUnknownCommand(t *testing.T) {
+	svc := agentmocks.NewService(t)
+	b := newTestBroker(t, svc)
+	// No handler, no secret lookup: an unknown command is dropped without panic
+	// and without consulting the service.
+	b.handleMsg(fakeMessage{payload: cmdPack(t, "u1", "does-not-exist", "")})
+}
+
+func TestHelpCommandPublishesRegistry(t *testing.T) {
+	svc := agentmocks.NewService(t)
+	svc.EXPECT().CommandSecret().Return("").Maybe()
+
+	var published string
+	svc.EXPECT().Publish(control, mock.Anything).Run(func(_ string, payload string) {
+		published = payload
+	}).Return(nil).Once()
+
+	b := newTestBroker(t, svc)
+	b.handleMsg(fakeMessage{payload: cmdPack(t, "u1", help, "")})
+
+	require.NotEmpty(t, published, "help must publish a response")
+	// The response is a SenML pack whose string value is the JSON command list.
+	records, err := senml.Decode([]byte(published))
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+	require.NotNil(t, records[0].StringValue)
+	for _, name := range []string{route, control, exec, help} {
+		assert.Contains(t, *records[0].StringValue, name)
+	}
+}
+
+func TestOTAStatusCommandPublishesStatus(t *testing.T) {
+	svc := agentmocks.NewService(t)
+	svc.EXPECT().CommandSecret().Return("").Maybe()
+	svc.EXPECT().OTAStatus().Return(agent.OTAStatusInfo{Busy: true}).Once()
+
+	var published string
+	svc.EXPECT().Publish(control, mock.Anything).Run(func(_ string, payload string) {
+		published = payload
+	}).Return(nil).Once()
+
+	b := newTestBroker(t, svc)
+	b.handleMsg(fakeMessage{payload: cmdPack(t, "u1", otaCmd, otaStatus)})
+
+	require.NotEmpty(t, published)
+	records, err := senml.Decode([]byte(published))
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+	require.NotNil(t, records[0].StringValue)
+	assert.Contains(t, *records[0].StringValue, "busy")
+}
+
+var _ mqtt.Message = fakeMessage{}

--- a/service.go
+++ b/service.go
@@ -53,6 +53,12 @@ const (
 	control = "control"
 	data    = "data"
 
+	// control subcommands for agent lifecycle management.
+	ctrlStop   = "stop"
+	ctrlStart  = "start"
+	ctrlReload = "reload"
+	ctrlStatus = "status"
+
 	export = "export"
 
 	keyLogLevel               = "log_level"
@@ -140,6 +146,9 @@ var (
 
 	// errDeviceManagerDisabled indicates device manager is not configured.
 	errDeviceManagerDisabled = errors.New("device manager not configured")
+
+	// errRouteFailed indicates a failure routing a command to a downstream device.
+	errRouteFailed = errors.New("failed to route command to device")
 )
 
 // DeviceService groups the downstream-device management methods of Service.
@@ -171,6 +180,11 @@ type Service interface {
 
 	// Control command.
 	Control(uuid, cmdStr string) error
+
+	// Route forwards a raw payload to a downstream device's physical interface
+	// and publishes the device's response. cmdStr is comma-delimited:
+	// <device_id>,<hex_payload>[,<read_bytes>].
+	Route(ctx context.Context, uuid, cmdStr string) error
 
 	// Update configuration file.
 	AddConfig(Config) error
@@ -264,6 +278,8 @@ type agent struct {
 	otaCancel           context.CancelFunc
 	otaAborted          atomic.Bool
 	bootstrapCachePath  string
+	runCtx              context.Context
+	paused              atomic.Bool
 }
 
 // New returns agent service implementation.
@@ -284,6 +300,7 @@ func New(ctx context.Context, mc paho.Client, cfg *Config, nc nodered.Client, lo
 		logLevel:            levelVar,
 		startupConfig:       *cfg,
 		bootstrapCachePath:  bootstrapCachePath,
+		runCtx:              ctx,
 	}
 
 	if devices != nil {
@@ -377,6 +394,14 @@ func (a *agent) Control(uuid, cmdStr string) error {
 
 	cmd := cmdArgs[0]
 	switch {
+	case cmd == ctrlStop:
+		resp = a.controlStop()
+	case cmd == ctrlStart:
+		resp = a.controlStart()
+	case cmd == ctrlReload:
+		resp = a.controlReload()
+	case cmd == ctrlStatus:
+		resp, err = a.controlStatus()
 	case strings.HasPrefix(cmd, "nodered-"):
 		resp, err = a.NodeRed(cmdStr)
 	default:
@@ -388,6 +413,120 @@ func (a *agent) Control(uuid, cmdStr string) error {
 	}
 
 	return a.processResponse(uuid, cmd, resp)
+}
+
+// controlStop pauses the agent's background publishing loops (heartbeat and
+// telemetry) and stops the per-device scheduler. The process stays alive so a
+// subsequent control,start can resume it.
+func (a *agent) controlStop() string {
+	a.paused.Store(true)
+	if a.sched != nil {
+		a.sched.Stop()
+	}
+	a.logger.Info("Agent paused via control command")
+	return "stopped"
+}
+
+// controlStart resumes the background publishing loops and restarts the
+// per-device scheduler using the agent's run context.
+func (a *agent) controlStart() string {
+	a.paused.Store(false)
+	if a.sched != nil && a.runCtx != nil {
+		if err := a.sched.Start(a.runCtx); err != nil {
+			a.logger.Warn("Failed to restart device scheduler", slog.Any("error", err))
+		}
+	}
+	a.logger.Info("Agent resumed via control command")
+	return "started"
+}
+
+// controlReload re-applies persisted runtime config overrides from the store so
+// that out-of-band changes to the store take effect without a restart.
+func (a *agent) controlReload() string {
+	if a.store == nil {
+		return notConfigured
+	}
+	for key, val := range a.store.All() {
+		if !settableKeys[key] {
+			continue
+		}
+		a.cfgMu.Lock()
+		ApplyConfigEntry(a.config, key, val)
+		a.cfgMu.Unlock()
+		a.applyLiveUpdate(key, val)
+	}
+	a.logger.Info("Agent config reloaded via control command")
+	return "reloaded"
+}
+
+// controlStatus reports the agent's current runtime state as a JSON document.
+func (a *agent) controlStatus() (string, error) {
+	status := struct {
+		Running       bool    `json:"running"`
+		Paused        bool    `json:"paused"`
+		UptimeSeconds float64 `json:"uptime_seconds"`
+		Version       string  `json:"version"`
+	}{
+		Running:       true,
+		Paused:        a.paused.Load(),
+		UptimeSeconds: time.Since(startTime).Seconds(),
+		Version:       Version,
+	}
+	b, err := json.Marshal(status)
+	if err != nil {
+		return "", errors.New(err.Error())
+	}
+	return string(b), nil
+}
+
+// Route forwards a raw payload to a downstream device's physical interface and
+// publishes the device's response. cmdStr is comma-delimited:
+//
+//	<device_id>,<hex_payload>[,<read_bytes>]
+//
+// The interface is opened if not already open, the hex payload is written, and
+// when read_bytes is supplied (0 < n <= 65536) that many bytes are read back
+// and returned as a hex string. With no read_bytes, the number of bytes written
+// is returned.
+func (a *agent) Route(_ context.Context, uuid, cmdStr string) error {
+	if a.devices == nil {
+		return errors.Wrap(errRouteFailed, errDeviceManagerDisabled)
+	}
+
+	args := strings.Split(strings.ReplaceAll(cmdStr, " ", ""), ",")
+	if len(args) < 2 || args[0] == "" || args[1] == "" {
+		return errors.Wrap(errRouteFailed, errInvalidCommand)
+	}
+	deviceID, hexPayload := args[0], args[1]
+
+	readBytes := 0
+	if len(args) >= 3 && args[2] != "" {
+		n, perr := strconv.Atoi(args[2])
+		if perr != nil || n <= 0 || n > 65536 {
+			return errors.Wrap(errRouteFailed, errInvalidCommand)
+		}
+		readBytes = n
+	}
+
+	if err := a.devices.OpenIface(deviceID); err != nil {
+		return errors.Wrap(errRouteFailed, err)
+	}
+
+	written, err := a.devices.WriteIface(deviceID, hexPayload)
+	if err != nil {
+		return errors.Wrap(errRouteFailed, err)
+	}
+
+	resp := strconv.Itoa(written)
+	if readBytes > 0 {
+		read, rerr := a.devices.ReadIface(deviceID, readBytes)
+		if rerr != nil {
+			return errors.Wrap(errRouteFailed, rerr)
+		}
+		resp = fmt.Sprintf("%x", read)
+	}
+
+	return a.processResponse(uuid, "route", resp)
 }
 
 // Message for this command
@@ -895,6 +1034,9 @@ func (a *agent) publish(t, payload string, qos byte) error {
 
 func (a *agent) selfHeartbeat(ctx context.Context, topic string, interval time.Duration, qos byte) {
 	publish := func() {
+		if a.paused.Load() {
+			return
+		}
 		payload, err := a.selfHeartbeatPayload()
 		if err != nil {
 			a.logger.Error("failed to encode self-heartbeat", slog.Any("error", err))
@@ -961,6 +1103,9 @@ func (a *agent) selfHeartbeatPayload() ([]byte, error) {
 
 func (a *agent) selfTelemetry(ctx context.Context, topic string, interval time.Duration, qos byte) {
 	publish := func() {
+		if a.paused.Load() {
+			return
+		}
 		records := a.gatewayTelemetryPayload()
 		if len(records) == 0 {
 			return

--- a/service.go
+++ b/service.go
@@ -428,10 +428,19 @@ func (a *agent) controlStop() string {
 }
 
 // controlStart resumes the background publishing loops and restarts the
-// per-device scheduler using the agent's run context.
+// per-device scheduler using the agent's run context. The scheduler context
+// descends from the process context passed to New so device goroutines still
+// terminate on shutdown; if that context is already cancelled (process is
+// shutting down) the scheduler is not restarted.
 func (a *agent) controlStart() string {
 	a.paused.Store(false)
-	if a.sched != nil && a.runCtx != nil {
+	switch {
+	case a.sched == nil:
+		// No device scheduler configured; nothing to restart.
+	case a.runCtx == nil || a.runCtx.Err() != nil:
+		a.logger.Warn("Run context unavailable; device scheduler not restarted",
+			slog.Any("error", contextErr(a.runCtx)))
+	default:
 		if err := a.sched.Start(a.runCtx); err != nil {
 			a.logger.Warn("Failed to restart device scheduler", slog.Any("error", err))
 		}
@@ -440,23 +449,45 @@ func (a *agent) controlStart() string {
 	return "started"
 }
 
+// contextErr returns ctx.Err() guarding against a nil context.
+func contextErr(ctx context.Context) error {
+	if ctx == nil {
+		return context.Canceled
+	}
+	return ctx.Err()
+}
+
 // controlReload re-applies persisted runtime config overrides from the store so
-// that out-of-band changes to the store take effect without a restart.
+// that out-of-band changes to the store take effect without a restart. Each
+// value is validated before being applied; invalid entries (e.g. from manual
+// file edits) are skipped and logged. The response lists the keys that were
+// applied for auditability.
 func (a *agent) controlReload() string {
 	if a.store == nil {
 		return notConfigured
 	}
+	var applied []string
 	for key, val := range a.store.All() {
 		if !settableKeys[key] {
+			continue
+		}
+		if err := validateSettableValue(key, val); err != nil {
+			a.logger.Warn("Skipping invalid persisted config value on reload",
+				slog.String("key", key), slog.Any("error", err))
 			continue
 		}
 		a.cfgMu.Lock()
 		ApplyConfigEntry(a.config, key, val)
 		a.cfgMu.Unlock()
 		a.applyLiveUpdate(key, val)
+		applied = append(applied, key)
 	}
-	a.logger.Info("Agent config reloaded via control command")
-	return "reloaded"
+	sort.Strings(applied)
+	a.logger.Info("Agent config reloaded via control command", slog.Any("applied", applied))
+	if len(applied) == 0 {
+		return "reloaded"
+	}
+	return "reloaded:" + strings.Join(applied, ",")
 }
 
 // controlStatus reports the agent's current runtime state as a JSON document.
@@ -506,6 +537,12 @@ func (a *agent) Route(_ context.Context, uuid, cmdStr string) error {
 			return errors.Wrap(errRouteFailed, errInvalidCommand)
 		}
 		readBytes = n
+	}
+
+	// Resolve the device first so a missing device returns a clear error rather
+	// than surfacing as an opaque interface-open failure.
+	if _, err := a.devices.Get(deviceID); err != nil {
+		return errors.Wrap(errRouteFailed, err)
 	}
 
 	if err := a.devices.OpenIface(deviceID); err != nil {

--- a/service_test.go
+++ b/service_test.go
@@ -2022,11 +2022,32 @@ func TestControlSubcommands(t *testing.T) {
 		expectMQTTPublish(t, mqttClient, mqttTopic("ctrl-channel", "res"), byte(1), nil).Run(func(args mock.Arguments) {
 			rec := decodeFirstRecord(t, args.Get(3))
 			require.NotNil(t, rec.StringValue)
-			assert.Equal(t, "reloaded", *rec.StringValue)
+			assert.Equal(t, "reloaded:log_level", *rec.StringValue, "response should list applied keys")
 		})
 
 		require.NoError(t, svc.Control("uuid", "reload"))
 		assert.Equal(t, "error", svc.Config().Log.Level, "reload should apply persisted log_level override")
+	})
+
+	t.Run("reload validates and skips invalid persisted values", func(t *testing.T) {
+		store, storeErr := cfgstore.NewStore(filepath.Join(t.TempDir(), "config.json"))
+		require.NoError(t, storeErr)
+		require.NoError(t, store.Set("log_level", "not-a-level")) // invalid, must be skipped
+		require.NoError(t, store.Set("heartbeat_interval", "30s"))
+
+		cfg := testConfig()
+		svc, mqttClient, _, err := newService(t, cfg, store)
+		require.NoError(t, err)
+
+		expectMQTTPublish(t, mqttClient, mqttTopic("ctrl-channel", "res"), byte(1), nil).Run(func(args mock.Arguments) {
+			rec := decodeFirstRecord(t, args.Get(3))
+			require.NotNil(t, rec.StringValue)
+			assert.Equal(t, "reloaded:heartbeat_interval", *rec.StringValue)
+		})
+
+		require.NoError(t, svc.Control("uuid", "reload"))
+		assert.Equal(t, "debug", svc.Config().Log.Level, "invalid log_level must be skipped")
+		assert.Equal(t, 30*time.Second, svc.Config().Heartbeat.Interval, "valid override should apply")
 	})
 
 	t.Run("reload without store reports not configured", func(t *testing.T) {

--- a/service_test.go
+++ b/service_test.go
@@ -1924,3 +1924,147 @@ func TestDeviceManager(t *testing.T) {
 		})
 	}
 }
+
+func newEmptyManager(t *testing.T) *devicemgr.Manager {
+	t.Helper()
+	m, err := devicemgr.New(
+		filepath.Join(t.TempDir(), "devices.db"),
+		devicemgr.ProvisionConfig{},
+		iface.Config{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = m.Close() })
+	return m
+}
+
+func TestRoute(t *testing.T) {
+	t.Run("error when device manager disabled", func(t *testing.T) {
+		svc, _, _, err := newService(t, testConfig(), nil)
+		require.NoError(t, err)
+		assert.Error(t, svc.Route(context.Background(), "uuid", "dev,01a2ff,16"))
+	})
+
+	cases := []struct {
+		desc   string
+		cmdStr string
+	}{
+		{desc: "empty command", cmdStr: ""},
+		{desc: "missing payload", cmdStr: "dev"},
+		{desc: "blank payload", cmdStr: "dev,"},
+		{desc: "non-numeric read bytes", cmdStr: "dev,01,bad"},
+		{desc: "zero read bytes", cmdStr: "dev,01,0"},
+		{desc: "read bytes over limit", cmdStr: "dev,01,70000"},
+		{desc: "unknown device write", cmdStr: "dev,01a2ff"},
+		{desc: "unknown device read", cmdStr: "dev,01a2ff,16"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			mgr := newEmptyManager(t)
+			svc, _, _, err := newService(t, testConfig(), nil, mgr)
+			require.NoError(t, err)
+			// All cases fail before a successful round-trip, so no response is
+			// published; the error is returned to the caller.
+			assert.Error(t, svc.Route(context.Background(), "uuid", tc.cmdStr))
+		})
+	}
+}
+
+func TestControlSubcommands(t *testing.T) {
+	t.Run("status reports running state", func(t *testing.T) {
+		cfg := testConfig()
+		svc, mqttClient, _, err := newService(t, cfg, nil)
+		require.NoError(t, err)
+
+		expectMQTTPublish(t, mqttClient, mqttTopic("ctrl-channel", "res"), byte(1), nil).Run(func(args mock.Arguments) {
+			rec := decodeFirstRecord(t, args.Get(3))
+			assert.Equal(t, "status", rec.Name)
+			require.NotNil(t, rec.StringValue)
+			assert.Contains(t, *rec.StringValue, `"running":true`)
+			assert.Contains(t, *rec.StringValue, `"paused":false`)
+		})
+
+		require.NoError(t, svc.Control("uuid", "status"))
+	})
+
+	t.Run("stop then start", func(t *testing.T) {
+		cfg := testConfig()
+		svc, mqttClient, _, err := newService(t, cfg, nil)
+		require.NoError(t, err)
+
+		expectMQTTPublish(t, mqttClient, mqttTopic("ctrl-channel", "res"), byte(1), nil).Run(func(args mock.Arguments) {
+			rec := decodeFirstRecord(t, args.Get(3))
+			assert.Equal(t, "stop", rec.Name)
+			require.NotNil(t, rec.StringValue)
+			assert.Equal(t, "stopped", *rec.StringValue)
+		})
+		require.NoError(t, svc.Control("uuid", "stop"))
+
+		expectMQTTPublish(t, mqttClient, mqttTopic("ctrl-channel", "res"), byte(1), nil).Run(func(args mock.Arguments) {
+			rec := decodeFirstRecord(t, args.Get(3))
+			assert.Equal(t, "start", rec.Name)
+			require.NotNil(t, rec.StringValue)
+			assert.Equal(t, "started", *rec.StringValue)
+		})
+		require.NoError(t, svc.Control("uuid", "start"))
+	})
+
+	t.Run("reload re-applies persisted overrides", func(t *testing.T) {
+		store, storeErr := cfgstore.NewStore(filepath.Join(t.TempDir(), "config.json"))
+		require.NoError(t, storeErr)
+		require.NoError(t, store.Set("log_level", "error"))
+
+		cfg := testConfig()
+		svc, mqttClient, _, err := newService(t, cfg, store)
+		require.NoError(t, err)
+		require.Equal(t, "debug", svc.Config().Log.Level)
+
+		expectMQTTPublish(t, mqttClient, mqttTopic("ctrl-channel", "res"), byte(1), nil).Run(func(args mock.Arguments) {
+			rec := decodeFirstRecord(t, args.Get(3))
+			require.NotNil(t, rec.StringValue)
+			assert.Equal(t, "reloaded", *rec.StringValue)
+		})
+
+		require.NoError(t, svc.Control("uuid", "reload"))
+		assert.Equal(t, "error", svc.Config().Log.Level, "reload should apply persisted log_level override")
+	})
+
+	t.Run("reload without store reports not configured", func(t *testing.T) {
+		cfg := testConfig()
+		svc, mqttClient, _, err := newService(t, cfg, nil)
+		require.NoError(t, err)
+
+		expectMQTTPublish(t, mqttClient, mqttTopic("ctrl-channel", "res"), byte(1), nil).Run(func(args mock.Arguments) {
+			rec := decodeFirstRecord(t, args.Get(3))
+			require.NotNil(t, rec.StringValue)
+			assert.Equal(t, "not_configured", *rec.StringValue)
+		})
+
+		require.NoError(t, svc.Control("uuid", "reload"))
+	})
+
+	t.Run("unknown subcommand errors", func(t *testing.T) {
+		cfg := testConfig()
+		svc, _, _, err := newService(t, cfg, nil)
+		require.NoError(t, err)
+		assert.Error(t, svc.Control("uuid", "bogus"))
+	})
+}
+
+// decodeFirstRecord decodes a published SenML payload and returns its first record.
+func decodeFirstRecord(t *testing.T, payload interface{}) senml.Record {
+	t.Helper()
+	var b []byte
+	switch p := payload.(type) {
+	case []byte:
+		b = p
+	case string:
+		b = []byte(p)
+	default:
+		t.Fatalf("unexpected payload type %T", payload)
+	}
+	pack, err := senml.Decode(b, senml.JSON)
+	require.NoError(t, err)
+	require.NotEmpty(t, pack.Records)
+	return pack.Records[0]
+}


### PR DESCRIPTION
### What does this do?
Adds an extensible command registry with metadata, a help command, per-command auth, plus route, control lifecycle, and ota status commands.

### Which issue(s) does this PR fix/relate to?
Resolves #81

### List any changes that modify/break current functionality
None breaking. Authorization moves from a global gate to per-command; all built-ins still require a token.

### Have you included tests for your changes?
Yes — registry, per-command auth, help, ota status, route validation, and all control subcommands are covered.

### Did you document any new/modified functionality?
Yes — README command table and usage examples updated for help, control, ota status, and route.

### Notes
New commands are MQTT-only (SenML), matching the issue format; no HTTP endpoints added.
