### PR TITLE
AGT-79 - Publish OTA Progress and Status to MQTT

### DIFF
--- a/docs/ota.md
+++ b/docs/ota.md
@@ -66,24 +66,51 @@ No dispatch record is needed; the entire pack is trigger fields:
 
 | Field  | Required | Description                                                                                       |
 | ------ | -------- | ------------------------------------------------------------------------------------------------- |
-| `url`  | Yes      | HTTP/HTTPS URL to the new binary                                                                  |
+| `url`  | Cond.    | HTTP/HTTPS URL to the new binary. Omit on the `ota/cfg` topic to prime MQTT data delivery instead |
 | `hash` | No       | Hex-encoded SHA-256 digest. If omitted, the agent tries to fetch `<url>.sha256` as a sidecar file |
 | `size` | No       | Expected byte count. If non-zero, the download is aborted if it exceeds this value                |
 
+### Via MQTT data delivery (no HTTP)
+
+For environments without outbound HTTP, firmware can be delivered over MQTT. First **prime** the agent with an `ota/cfg` message carrying `hash` (and optionally `size`) but **no** `url`:
+
+```json
+[
+  { "n": "hash", "vs": "<sha256-hex>" },
+  { "n": "size", "v": 8388608 }
+]
+```
+
+Then publish the raw binary to the **OTA data topic**:
+
+**Topic:** `m/<domain-id>/c/<commands-channel-id>/ota`
+
+The agent installs the payload only if it matches the primed `size` (when given) and SHA-256 `hash`. A `hash` is **required** for MQTT-delivered firmware (there is no sidecar fallback). The binary is sent as a single MQTT message, so it is bounded by the broker's maximum packet size. A `url`-bearing `ota/cfg` trigger cancels any pending priming.
+
 ## Status Reporting
 
-During the OTA operation, the agent publishes progress to:
+During the OTA operation, the agent publishes a **retained** SenML status message on each state transition and at 5% download increments to:
 
 **Topic:** `m/<domain-id>/c/<commands-channel-id>/ota/status`
 
 ```json
 [
-  { "bn": "gw:", "bt": 1749552000.0, "n": "ota_state", "vs": "downloading" },
-  { "n": "ota_progress", "u": "%", "v": 50.0 }
+  { "bn": "gw:", "bt": 1749552000.0, "n": "state", "vs": "downloading" },
+  { "n": "bytes", "u": "By", "v": 65536 },
+  { "n": "total", "u": "By", "v": 1324740 },
+  { "n": "progress", "u": "%", "v": 50.0 }
 ]
 ```
 
-Progress is reported at 5% increments during download and at state transitions.
+| Field      | Unit | Description                                                                               |
+| ---------- | ---- | ----------------------------------------------------------------------------------------- |
+| `state`    | —    | `triggered`, `downloading`, `verifying`, `ready`, `restarting`, or `aborted`              |
+| `bytes`    | `By` | Bytes written to disk so far (meaningful during `downloading`)                            |
+| `total`    | `By` | Total expected bytes (content length; `0` when unknown)                                   |
+| `progress` | `%`  | Percentage complete, 0–100                                                                |
+| `error`    | —    | Error message; present only on failure (state `aborted`)                                  |
+
+Because the message is **retained**, a subscriber that connects mid-update (or after it) reads the last published status immediately. On failure, a final status carrying the `error` field is published.
 
 ## Verification
 
@@ -111,8 +138,9 @@ If a hash is provided or the sidecar is found, the downloaded file's SHA-256 mus
 | Direction     | Topic                                    | QoS | Description                                               |
 | ------------- | ---------------------------------------- | --- | --------------------------------------------------------- |
 | Cloud → Agent | `m/<domain-id>/c/<ctrl-chan>/req`        | 1   | Trigger via commands channel (uses `ota` dispatch record) |
-| Cloud → Agent | `m/<domain-id>/c/<ctrl-chan>/ota/cfg`    | 0   | Direct OTA config trigger                                 |
-| Agent → Cloud | `m/<domain-id>/c/<ctrl-chan>/ota/status` | QoS | Progress and state updates                                |
+| Cloud → Agent | `m/<domain-id>/c/<ctrl-chan>/ota/cfg`    | 0   | Direct OTA config trigger / MQTT-delivery priming         |
+| Cloud → Agent | `m/<domain-id>/c/<ctrl-chan>/ota`        | 0   | Firmware binary for MQTT delivery (after priming)         |
+| Agent → Cloud | `m/<domain-id>/c/<ctrl-chan>/ota/status` | QoS | Progress and state updates (retained)                     |
 
 ## MQTT Test Recipes
 
@@ -134,6 +162,29 @@ mosquitto_pub \
     -u <client-id> -P <client-secret> --id "ota-$(date +%s)" \
     -t "m/<domain-id>/c/<commands-channel-id>/ota/cfg" \
     -m '[{"n":"url","vs":"https://example.com/agent-v2"},{"n":"hash","vs":"abcdef1234567890..."}]'
+```
+
+### Deliver firmware over MQTT (no HTTP)
+
+Prime with the expected hash and size (no `url`), then publish the raw binary to the OTA data topic:
+
+```bash
+HASH=$(sha256sum agent-v2 | cut -d' ' -f1)
+SIZE=$(stat -c%s agent-v2)
+
+# 1. Prime the agent
+mosquitto_pub \
+    -h <mqtt-host> -p 1883 \
+    -u <client-id> -P <client-secret> --id "ota-$(date +%s)" \
+    -t "m/<domain-id>/c/<commands-channel-id>/ota/cfg" \
+    -m "[{\"n\":\"hash\",\"vs\":\"$HASH\"},{\"n\":\"size\",\"v\":$SIZE}]"
+
+# 2. Send the binary
+mosquitto_pub \
+    -h <mqtt-host> -p 1883 \
+    -u <client-id> -P <client-secret> --id "ota-$(date +%s)" \
+    -t "m/<domain-id>/c/<commands-channel-id>/ota" \
+    -f agent-v2
 ```
 
 ### Abort an in-progress OTA
@@ -181,12 +232,12 @@ mosquitto_sub \
 **Expected output:**
 
 ```
-m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"ota_state","vs":"triggered"},{"n":"ota_progress","u":"%","v":0}]
-m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"ota_state","vs":"downloading"},{"n":"ota_progress","u":"%","v":5}]
-m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"ota_state","vs":"downloading"},{"n":"ota_progress","u":"%","v":50}]
-m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"ota_state","vs":"verifying"},{"n":"ota_progress","u":"%","v":100}]
-m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"ota_state","vs":"ready"},{"n":"ota_progress","u":"%","v":100}]
-m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"ota_state","vs":"restarting"},{"n":"ota_progress","u":"%","v":100}]
+m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"triggered"},{"n":"bytes","u":"By","v":0},{"n":"total","u":"By","v":0},{"n":"progress","u":"%","v":0}]
+m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"downloading"},{"n":"bytes","u":"By","v":66237},{"n":"total","u":"By","v":1324740},{"n":"progress","u":"%","v":5}]
+m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"downloading"},{"n":"bytes","u":"By","v":662370},{"n":"total","u":"By","v":1324740},{"n":"progress","u":"%","v":50}]
+m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"verifying"},{"n":"bytes","u":"By","v":0},{"n":"total","u":"By","v":0},{"n":"progress","u":"%","v":100}]
+m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"ready"},{"n":"bytes","u":"By","v":0},{"n":"total","u":"By","v":0},{"n":"progress","u":"%","v":100}]
+m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"restarting"},{"n":"bytes","u":"By","v":0},{"n":"total","u":"By","v":0},{"n":"progress","u":"%","v":100}]
 ```
 
 ### Check OTA status via HTTP

--- a/docs/ota.md
+++ b/docs/ota.md
@@ -231,10 +231,15 @@ mosquitto_sub \
 
 **Expected output:**
 
+Download progress is published on every 5% step (`5, 10, 15, … 95, 100`); the lines below are abbreviated with `...`:
+
 ```
 m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"triggered"},{"n":"bytes","u":"By","v":0},{"n":"total","u":"By","v":0},{"n":"progress","u":"%","v":0}]
 m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"downloading"},{"n":"bytes","u":"By","v":66237},{"n":"total","u":"By","v":1324740},{"n":"progress","u":"%","v":5}]
-m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"downloading"},{"n":"bytes","u":"By","v":662370},{"n":"total","u":"By","v":1324740},{"n":"progress","u":"%","v":50}]
+m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"downloading"},{"n":"bytes","u":"By","v":132474},{"n":"total","u":"By","v":1324740},{"n":"progress","u":"%","v":10}]
+...
+m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"downloading"},{"n":"bytes","u":"By","v":1258503},{"n":"total","u":"By","v":1324740},{"n":"progress","u":"%","v":95}]
+m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"downloading"},{"n":"bytes","u":"By","v":1324740},{"n":"total","u":"By","v":1324740},{"n":"progress","u":"%","v":100}]
 m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"verifying"},{"n":"bytes","u":"By","v":0},{"n":"total","u":"By","v":0},{"n":"progress","u":"%","v":100}]
 m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"ready"},{"n":"bytes","u":"By","v":0},{"n":"total","u":"By","v":0},{"n":"progress","u":"%","v":100}]
 m/<domain-id>/c/<ctrl-chan>/ota/status [{"bn":"gw:","bt":...,"n":"state","vs":"restarting"},{"n":"bytes","u":"By","v":0},{"n":"total","u":"By","v":0},{"n":"progress","u":"%","v":100}]

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -242,6 +242,24 @@ func (lm *loggingMiddleware) OTA(ctx context.Context, url, sha256hex string, siz
 	return lm.svc.OTA(ctx, url, sha256hex, size)
 }
 
+func (lm *loggingMiddleware) OTAFromData(ctx context.Context, data []byte, sha256hex string) (err error) {
+	defer func(begin time.Time) {
+		args := []any{
+			slog.String("duration", time.Since(begin).String()),
+			slog.Int("bytes", len(data)),
+			slog.String("sha256hex", sha256hex),
+		}
+		if err != nil {
+			args = append(args, slog.String("error", err.Error()))
+			lm.logger.Warn("OTA from data failed to complete successfully.", args...)
+			return
+		}
+		lm.logger.Info("OTA from data completed successfully.", args...)
+	}(time.Now())
+
+	return lm.svc.OTAFromData(ctx, data, sha256hex)
+}
+
 func (lm *loggingMiddleware) NodeRed(cmdStr string) (resp string, err error) {
 	defer func(begin time.Time) {
 		args := []any{

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -158,6 +158,15 @@ func (ms *metricsMiddleware) OTA(ctx context.Context, url, sha256hex string, siz
 	return ms.svc.OTA(ctx, url, sha256hex, size)
 }
 
+func (ms *metricsMiddleware) OTAFromData(ctx context.Context, data []byte, sha256hex string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "ota_from_data").Add(1)
+		ms.latency.With("method", "ota_from_data").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.OTAFromData(ctx, data, sha256hex)
+}
+
 func (ms *metricsMiddleware) NodeRed(cmdStr string) (string, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "nodered").Add(1)

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -796,6 +796,69 @@ func (_c *Service_OTAAbort_Call) RunAndReturn(run func() error) *Service_OTAAbor
 	return _c
 }
 
+// OTAFromData provides a mock function for the type Service
+func (_mock *Service) OTAFromData(ctx context.Context, data []byte, sha256hex string) error {
+	ret := _mock.Called(ctx, data, sha256hex)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OTAFromData")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []byte, string) error); ok {
+		r0 = returnFunc(ctx, data, sha256hex)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Service_OTAFromData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OTAFromData'
+type Service_OTAFromData_Call struct {
+	*mock.Call
+}
+
+// OTAFromData is a helper method to define mock.On call
+//   - ctx context.Context
+//   - data []byte
+//   - sha256hex string
+func (_e *Service_Expecter) OTAFromData(ctx interface{}, data interface{}, sha256hex interface{}) *Service_OTAFromData_Call {
+	return &Service_OTAFromData_Call{Call: _e.mock.On("OTAFromData", ctx, data, sha256hex)}
+}
+
+func (_c *Service_OTAFromData_Call) Run(run func(ctx context.Context, data []byte, sha256hex string)) *Service_OTAFromData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []byte
+		if args[1] != nil {
+			arg1 = args[1].([]byte)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *Service_OTAFromData_Call) Return(err error) *Service_OTAFromData_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Service_OTAFromData_Call) RunAndReturn(run func(ctx context.Context, data []byte, sha256hex string) error) *Service_OTAFromData_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // OTAStatus provides a mock function for the type Service
 func (_mock *Service) OTAStatus() agent.OTAStatusInfo {
 	ret := _mock.Called()

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -497,6 +497,11 @@ func (b *broker) handleOTACfgMsg(ctx context.Context, msg mqtt.Message) {
 	cfg := ota.ParseCfgFromRecords(records)
 
 	if cfg.URL != "" {
+		// A URL trigger supersedes any pending data-path priming so a later
+		// stray ota data message can't install against a stale hash.
+		b.otaPrepMu.Lock()
+		b.otaPrep = nil
+		b.otaPrepMu.Unlock()
 		b.logger.Info("OTA cfg HTTP download", slog.String("url", cfg.URL))
 		go func(ctx context.Context) {
 			if err := b.svc.OTA(ctx, cfg.URL, cfg.SHA256Hex, cfg.Size); err != nil {
@@ -519,6 +524,10 @@ func (b *broker) handleOTACfgMsg(ctx context.Context, msg mqtt.Message) {
 
 // handleOTADataMsg receives firmware binary on the ota data topic and installs it.
 // A prior ota/cfg message without a url must have primed the expected hash and size.
+//
+// The data topic carries no token of its own; trust rests entirely on the prior
+// authenticated ota/cfg priming and on OTAFromData verifying the payload against
+// the primed SHA-256 hash before install. Payloads that don't match are rejected.
 func (b *broker) handleOTADataMsg(ctx context.Context, msg mqtt.Message) {
 	b.otaPrepMu.Lock()
 	prep := b.otaPrep

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -24,10 +24,17 @@ import (
 	"robpike.io/filter"
 )
 
+// otaDataPrep holds the expected hash and size for firmware arriving on the ota data topic.
+type otaDataPrep struct {
+	hash string
+	size uint64
+}
+
 const (
-	reqTopic    = "req"
-	servTopic   = "services"
-	otaCfgTopic = "ota/cfg"
+	reqTopic     = "req"
+	servTopic    = "services"
+	otaCfgTopic  = "ota/cfg"
+	otaDataTopic = "ota"
 
 	control = "control"
 	exec    = "exec"
@@ -91,14 +98,16 @@ type MqttBroker interface {
 }
 
 type broker struct {
-	svc      agent.Service
-	client   mqtt.Client
-	logger   *slog.Logger
-	channel  string
-	domainID string
-	ctx      context.Context
-	commands map[string]Command
-	mu       sync.RWMutex
+	svc       agent.Service
+	client    mqtt.Client
+	logger    *slog.Logger
+	channel   string
+	domainID  string
+	ctx       context.Context
+	commands  map[string]Command
+	mu        sync.RWMutex
+	otaPrep   *otaDataPrep
+	otaPrepMu sync.Mutex
 }
 
 // NewBroker returns a new MQTT broker instance with all built-in command
@@ -436,6 +445,11 @@ func (b *broker) subscribe() error {
 	if err := o.Error(); o.Wait() && err != nil {
 		return err
 	}
+	topic = fmt.Sprintf("m/%s/c/%s/%s", b.domainID, b.channel, otaDataTopic)
+	d := b.client.Subscribe(topic, 0, func(_ mqtt.Client, msg mqtt.Message) { b.handleOTADataMsg(b.ctx, msg) })
+	if err := d.Error(); d.Wait() && err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -458,6 +472,9 @@ func (b *broker) handleBrokerMsg(msg mqtt.Message) {
 // handleOTACfgMsg handles OTA trigger messages arriving on the ota/cfg topic.
 // The payload is a SenML pack with url, hash, and size records.
 // If a command secret is configured, the pack must include a valid token record.
+// When url is present, firmware is fetched via HTTP. When url is absent, the
+// hash and size are stored so the next message on the ota data topic can be
+// installed directly.
 func (b *broker) handleOTACfgMsg(ctx context.Context, msg mqtt.Message) {
 	records, err := senml.Decode(msg.Payload())
 	if err != nil {
@@ -477,16 +494,54 @@ func (b *broker) handleOTACfgMsg(ctx context.Context, msg mqtt.Message) {
 		}
 	}
 
-	trigger, err := ota.TriggerFromRecords(records)
-	if err != nil {
-		b.logger.Warn("OTA cfg trigger parse failed", slog.Any("error", err))
+	cfg := ota.ParseCfgFromRecords(records)
+
+	if cfg.URL != "" {
+		b.logger.Info("OTA cfg HTTP download", slog.String("url", cfg.URL))
+		go func(ctx context.Context) {
+			if err := b.svc.OTA(ctx, cfg.URL, cfg.SHA256Hex, cfg.Size); err != nil {
+				b.logger.Warn("OTA cfg HTTP operation failed", slog.Any("error", err))
+			}
+		}(context.WithoutCancel(ctx))
 		return
 	}
 
-	b.logger.Info("OTA cfg command", slog.String("url", trigger.URL))
+	if cfg.SHA256Hex == "" {
+		b.logger.Warn("OTA cfg has no url and no hash; ignoring")
+		return
+	}
+
+	b.otaPrepMu.Lock()
+	b.otaPrep = &otaDataPrep{hash: cfg.SHA256Hex, size: cfg.Size}
+	b.otaPrepMu.Unlock()
+	b.logger.Info("OTA cfg primed for MQTT data delivery", slog.String("hash", cfg.SHA256Hex), slog.Uint64("size", cfg.Size))
+}
+
+// handleOTADataMsg receives firmware binary on the ota data topic and installs it.
+// A prior ota/cfg message without a url must have primed the expected hash and size.
+func (b *broker) handleOTADataMsg(ctx context.Context, msg mqtt.Message) {
+	b.otaPrepMu.Lock()
+	prep := b.otaPrep
+	b.otaPrep = nil
+	b.otaPrepMu.Unlock()
+
+	if prep == nil {
+		b.logger.Warn("OTA data received with no prior cfg priming; ignoring")
+		return
+	}
+
+	data := msg.Payload()
+	if prep.size > 0 && uint64(len(data)) != prep.size {
+		b.logger.Warn("OTA data size mismatch",
+			slog.Int("got", len(data)),
+			slog.Uint64("expected", prep.size))
+		return
+	}
+
+	b.logger.Info("OTA data received via MQTT", slog.Int("bytes", len(data)))
 	go func(ctx context.Context) {
-		if err := b.svc.OTA(ctx, trigger.URL, trigger.SHA256Hex, trigger.Size); err != nil {
-			b.logger.Warn("OTA cfg operation failed", slog.Any("error", err))
+		if err := b.svc.OTAFromData(ctx, data, prep.hash); err != nil {
+			b.logger.Warn("OTA data operation failed", slog.Any("error", err))
 		}
 	}(context.WithoutCancel(ctx))
 }

--- a/pkg/ota/ota.go
+++ b/pkg/ota/ota.go
@@ -6,7 +6,6 @@ package ota
 import (
 	"context"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -61,8 +60,9 @@ func (s State) String() string {
 }
 
 // ProgressFn is called on state transitions and during download.
-// bytesWritten and totalBytes are bytes on disk; they are only meaningful during
-// StateDownloading. progress is 0–100 and is only meaningful in StateDownloading.
+// bytesWritten and totalBytes are bytes on disk; during StateDownloading they
+// reflect the running count, and in all later states they report the final file
+// size. progress is 0–100 and is only meaningful in StateDownloading.
 type ProgressFn func(state State, bytesWritten, totalBytes int64, progress float64)
 
 // Config holds the OTA updater parameters.
@@ -98,7 +98,7 @@ func TriggerFromRecords(records []senml.Record) (Trigger, error) {
 			t.URL = strings.TrimSpace(*r.StringValue)
 		case fieldHash:
 			if r.StringValue != nil {
-				t.SHA256Hex = *r.StringValue
+				t.SHA256Hex = strings.TrimSpace(*r.StringValue)
 			}
 		case fieldSize:
 			if r.Value != nil {
@@ -125,7 +125,7 @@ func ParseCfgFromRecords(records []senml.Record) Trigger {
 			}
 		case fieldHash:
 			if r.StringValue != nil {
-				t.SHA256Hex = *r.StringValue
+				t.SHA256Hex = strings.TrimSpace(*r.StringValue)
 			}
 		case fieldSize:
 			if r.Value != nil {
@@ -153,19 +153,20 @@ func Run(ctx context.Context, cfg Config, url, sha256hex string, size uint64, pr
 		progressFn(StateDownloading, written, total, pct)
 	})
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			progressFn(StateAborted, 0, 0, 0)
-		}
 		return fmt.Errorf("ota download: %w", err)
 	}
 
-	progressFn(StateVerifying, 0, 0, 100)
+	// Report the actual file size for subsequent states so that subscribers
+	// see consistent bytes/total values across HTTP- and MQTT-delivered updates.
+	var totalBytes int64
+	if fi, statErr := os.Stat(tmpPath); statErr == nil {
+		totalBytes = fi.Size()
+	}
+
+	progressFn(StateVerifying, totalBytes, totalBytes, 100)
 	verified, err := verify(ctx, url, tmpPath, sha256hex)
 	if err != nil {
 		_ = os.Remove(tmpPath)
-		if errors.Is(err, context.Canceled) {
-			progressFn(StateAborted, 0, 0, 0)
-		}
 		return fmt.Errorf("ota verify: %w", err)
 	}
 	if !verified {
@@ -173,13 +174,13 @@ func Run(ctx context.Context, cfg Config, url, sha256hex string, size uint64, pr
 		return fmt.Errorf("ota verify: no hash provided and sidecar not found at %s.sha256; refusing unverified install", url)
 	}
 
-	progressFn(StateReady, 0, 0, 100)
+	progressFn(StateReady, totalBytes, totalBytes, 100)
 	if err := replace(tmpPath, cfg.BinaryPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("ota replace: %w", err)
 	}
 
-	progressFn(StateRestarting, 0, 0, 100)
+	progressFn(StateRestarting, totalBytes, totalBytes, 100)
 	return syscall.Exec(cfg.BinaryPath, os.Args, os.Environ())
 }
 
@@ -198,9 +199,12 @@ func RunFromData(ctx context.Context, cfg Config, data []byte, sha256hex string,
 	progressFn(StateTriggered, 0, totalBytes, 0)
 	progressFn(StateDownloading, 0, totalBytes, 0)
 
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("ota write: %w", err)
+	}
+
 	f, err := os.CreateTemp(cfg.DownloadDir, "agent-ota-*")
 	if err != nil {
-		progressFn(StateAborted, 0, totalBytes, 0)
 		return fmt.Errorf("ota create temp: %w", err)
 	}
 	tmpPath := f.Name()
@@ -208,23 +212,29 @@ func RunFromData(ctx context.Context, cfg Config, data []byte, sha256hex string,
 	if _, err := f.Write(data); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmpPath)
-		progressFn(StateAborted, 0, totalBytes, 0)
 		return fmt.Errorf("ota write: %w", err)
 	}
 	if err := f.Close(); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("ota close temp: %w", err)
 	}
+	if err := ctx.Err(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("ota write: %w", err)
+	}
 	progressFn(StateDownloading, totalBytes, totalBytes, 100)
 
 	progressFn(StateVerifying, totalBytes, totalBytes, 100)
-	if err := verifyFile(tmpPath, sha256hex); err != nil {
+	if err := verifyFile(ctx, tmpPath, sha256hex); err != nil {
 		_ = os.Remove(tmpPath)
-		progressFn(StateAborted, 0, totalBytes, 0)
 		return fmt.Errorf("ota verify: %w", err)
 	}
 
 	progressFn(StateReady, totalBytes, totalBytes, 100)
+	if err := ctx.Err(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("ota replace: %w", err)
+	}
 	if err := replace(tmpPath, cfg.BinaryPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("ota replace: %w", err)
@@ -319,16 +329,36 @@ func download(ctx context.Context, url, dir string, size uint64, pctFn func(writ
 	return tmpName, nil
 }
 
-// verifyFile checks the SHA-256 hash of the file at tmpPath against the expected hex digest.
-func verifyFile(tmpPath, sha256hex string) error {
+// verifyFile checks the SHA-256 hash of the file at tmpPath against the expected
+// hex digest. It respects ctx by checking for cancellation between read chunks so
+// that an aborted OTA does not wait for a large file to be fully hashed.
+func verifyFile(ctx context.Context, tmpPath, sha256hex string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	f, err := os.Open(tmpPath)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = f.Close() }()
 	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return err
+	buf := make([]byte, 32*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		n, rerr := f.Read(buf)
+		if n > 0 {
+			if _, werr := h.Write(buf[:n]); werr != nil {
+				return werr
+			}
+		}
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return rerr
+		}
 	}
 	got := fmt.Sprintf("%x", h.Sum(nil))
 	if got != sha256hex {
@@ -372,7 +402,7 @@ func verify(ctx context.Context, url, tmpPath, sha256hex string) (bool, error) {
 		expected = fields[0]
 	}
 
-	if err := verifyFile(tmpPath, expected); err != nil {
+	if err := verifyFile(ctx, tmpPath, expected); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/pkg/ota/ota.go
+++ b/pkg/ota/ota.go
@@ -61,8 +61,9 @@ func (s State) String() string {
 }
 
 // ProgressFn is called on state transitions and during download.
-// progress is 0–100 and is only meaningful in StateDownloading.
-type ProgressFn func(state State, progress float64)
+// bytesWritten and totalBytes are bytes on disk; they are only meaningful during
+// StateDownloading. progress is 0–100 and is only meaningful in StateDownloading.
+type ProgressFn func(state State, bytesWritten, totalBytes int64, progress float64)
 
 // Config holds the OTA updater parameters.
 type Config struct {
@@ -111,6 +112,30 @@ func TriggerFromRecords(records []senml.Record) (Trigger, error) {
 	return t, nil
 }
 
+// ParseCfgFromRecords parses OTA configuration fields from SenML records without
+// requiring a URL. Use this for MQTT data-path priming where firmware is delivered
+// via the ota data topic rather than via HTTP download.
+func ParseCfgFromRecords(records []senml.Record) Trigger {
+	var t Trigger
+	for _, r := range records {
+		switch r.Name {
+		case fieldURL:
+			if r.StringValue != nil {
+				t.URL = strings.TrimSpace(*r.StringValue)
+			}
+		case fieldHash:
+			if r.StringValue != nil {
+				t.SHA256Hex = *r.StringValue
+			}
+		case fieldSize:
+			if r.Value != nil {
+				t.Size = uint64(*r.Value)
+			}
+		}
+	}
+	return t
+}
+
 // Run executes the full OTA cycle: download → verify → replace → restart.
 // sha256hex is the expected SHA-256 hex digest; if empty the sidecar at url+".sha256" is tried.
 // size is the expected byte count; if non-zero the downloaded file is checked against it.
@@ -119,27 +144,27 @@ func TriggerFromRecords(records []senml.Record) (Trigger, error) {
 // On success it never returns (the process is replaced in-place).
 func Run(ctx context.Context, cfg Config, url, sha256hex string, size uint64, progressFn ProgressFn) error {
 	if progressFn == nil {
-		progressFn = func(State, float64) {}
+		progressFn = func(State, int64, int64, float64) {}
 	}
-	progressFn(StateTriggered, 0)
+	progressFn(StateTriggered, 0, 0, 0)
 
-	progressFn(StateDownloading, 0)
-	tmpPath, err := download(ctx, url, cfg.DownloadDir, size, func(pct float64) {
-		progressFn(StateDownloading, pct)
+	progressFn(StateDownloading, 0, 0, 0)
+	tmpPath, err := download(ctx, url, cfg.DownloadDir, size, func(written, total int64, pct float64) {
+		progressFn(StateDownloading, written, total, pct)
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			progressFn(StateAborted, 0)
+			progressFn(StateAborted, 0, 0, 0)
 		}
 		return fmt.Errorf("ota download: %w", err)
 	}
 
-	progressFn(StateVerifying, 100)
+	progressFn(StateVerifying, 0, 0, 100)
 	verified, err := verify(ctx, url, tmpPath, sha256hex)
 	if err != nil {
 		_ = os.Remove(tmpPath)
 		if errors.Is(err, context.Canceled) {
-			progressFn(StateAborted, 0)
+			progressFn(StateAborted, 0, 0, 0)
 		}
 		return fmt.Errorf("ota verify: %w", err)
 	}
@@ -148,20 +173,72 @@ func Run(ctx context.Context, cfg Config, url, sha256hex string, size uint64, pr
 		return fmt.Errorf("ota verify: no hash provided and sidecar not found at %s.sha256; refusing unverified install", url)
 	}
 
-	progressFn(StateReady, 100)
+	progressFn(StateReady, 0, 0, 100)
 	if err := replace(tmpPath, cfg.BinaryPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("ota replace: %w", err)
 	}
 
-	progressFn(StateRestarting, 100)
+	progressFn(StateRestarting, 0, 0, 100)
+	return syscall.Exec(cfg.BinaryPath, os.Args, os.Environ())
+}
+
+// RunFromData installs firmware from an in-memory binary payload instead of
+// downloading from HTTP. sha256hex must be the hex-encoded SHA-256 of data.
+// On success it never returns (the process is replaced in-place).
+func RunFromData(ctx context.Context, cfg Config, data []byte, sha256hex string, progressFn ProgressFn) error {
+	if progressFn == nil {
+		progressFn = func(State, int64, int64, float64) {}
+	}
+	if sha256hex == "" {
+		return fmt.Errorf("ota verify: hash required for MQTT-delivered firmware")
+	}
+
+	totalBytes := int64(len(data))
+	progressFn(StateTriggered, 0, totalBytes, 0)
+	progressFn(StateDownloading, 0, totalBytes, 0)
+
+	f, err := os.CreateTemp(cfg.DownloadDir, "agent-ota-*")
+	if err != nil {
+		progressFn(StateAborted, 0, totalBytes, 0)
+		return fmt.Errorf("ota create temp: %w", err)
+	}
+	tmpPath := f.Name()
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		progressFn(StateAborted, 0, totalBytes, 0)
+		return fmt.Errorf("ota write: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("ota close temp: %w", err)
+	}
+	progressFn(StateDownloading, totalBytes, totalBytes, 100)
+
+	progressFn(StateVerifying, totalBytes, totalBytes, 100)
+	if err := verifyFile(tmpPath, sha256hex); err != nil {
+		_ = os.Remove(tmpPath)
+		progressFn(StateAborted, 0, totalBytes, 0)
+		return fmt.Errorf("ota verify: %w", err)
+	}
+
+	progressFn(StateReady, totalBytes, totalBytes, 100)
+	if err := replace(tmpPath, cfg.BinaryPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("ota replace: %w", err)
+	}
+
+	progressFn(StateRestarting, totalBytes, totalBytes, 100)
 	return syscall.Exec(cfg.BinaryPath, os.Args, os.Environ())
 }
 
 // download fetches url into a temporary file under dir and returns its path.
 // If size is non-zero the stream is aborted as soon as written bytes exceed it.
-// pctFn is called each time download progress crosses a 5% threshold.
-func download(ctx context.Context, url, dir string, size uint64, pctFn func(float64)) (string, error) {
+// pctFn is called each time download progress crosses a 5% threshold with the
+// bytes written so far, the total content length (-1 if unknown), and the percentage.
+func download(ctx context.Context, url, dir string, size uint64, pctFn func(written, total int64, pct float64)) (string, error) {
 	u, err := neturl.Parse(url)
 	if err != nil {
 		return "", fmt.Errorf("invalid URL: %w", err)
@@ -196,7 +273,7 @@ func download(ctx context.Context, url, dir string, size uint64, pctFn func(floa
 	var written int64
 	lastPct := 0.0
 	buf := make([]byte, 32*1024)
-	pctFn(0)
+	pctFn(0, total, 0)
 
 	for {
 		if ctx.Err() != nil {
@@ -221,7 +298,7 @@ func download(ctx context.Context, url, dir string, size uint64, pctFn func(floa
 				pct := float64(written) / float64(total) * 100
 				if pct-lastPct >= 5 {
 					lastPct = pct
-					pctFn(pct)
+					pctFn(written, total, pct)
 				}
 			}
 		}
@@ -238,8 +315,26 @@ func download(ctx context.Context, url, dir string, size uint64, pctFn func(floa
 		_ = os.Remove(tmpName)
 		return "", err
 	}
-	pctFn(100)
+	pctFn(written, total, 100)
 	return tmpName, nil
+}
+
+// verifyFile checks the SHA-256 hash of the file at tmpPath against the expected hex digest.
+func verifyFile(tmpPath, sha256hex string) error {
+	f, err := os.Open(tmpPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	got := fmt.Sprintf("%x", h.Sum(nil))
+	if got != sha256hex {
+		return fmt.Errorf("sha256 mismatch: got %s, want %s", got, sha256hex)
+	}
+	return nil
 }
 
 // verify checks the SHA-256 of tmpPath.
@@ -277,18 +372,8 @@ func verify(ctx context.Context, url, tmpPath, sha256hex string) (bool, error) {
 		expected = fields[0]
 	}
 
-	f, err := os.Open(tmpPath)
-	if err != nil {
+	if err := verifyFile(tmpPath, expected); err != nil {
 		return false, err
-	}
-	defer func() { _ = f.Close() }()
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return false, err
-	}
-	got := fmt.Sprintf("%x", h.Sum(nil))
-	if got != expected {
-		return false, fmt.Errorf("sha256 mismatch: got %s, want %s", got, expected)
 	}
 	return true, nil
 }

--- a/pkg/ota/ota_test.go
+++ b/pkg/ota/ota_test.go
@@ -68,6 +68,11 @@ func TestParseCfgFromRecords(t *testing.T) {
 			records: []senml.Record{{Name: "url", StringValue: nil}},
 			wantURL: "",
 		},
+		{
+			desc:     "hash with surrounding whitespace is trimmed",
+			records:  []senml.Record{{Name: "hash", StringValue: func() *string { s := "  " + hashVal + "  "; return &s }()}},
+			wantHash: hashVal,
+		},
 	}
 
 	for _, tc := range cases {
@@ -125,8 +130,26 @@ func TestRunFromData(t *testing.T) {
 			if tc.wantErrContains != "" {
 				assert.ErrorContains(t, err, tc.wantErrContains)
 			}
+			// The library must not emit StateAborted; the service layer is the
+			// sole publisher of the aborted state (with the error message).
+			assert.NotContains(t, states, StateAborted, "library must not publish StateAborted")
 		})
 	}
+}
+
+func TestRunFromDataContextCancelled(t *testing.T) {
+	content := []byte("fake binary content for mqtt ota")
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "agent-dst")
+	cfg := Config{BinaryPath: dst, DownloadDir: dir}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := RunFromData(ctx, cfg, content, sha256hex(content),
+		func(State, int64, int64, float64) {})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestState_String(t *testing.T) {
@@ -221,6 +244,15 @@ func TestTriggerFromRecords(t *testing.T) {
 				{Name: "extra", StringValue: &hashVal},
 			},
 			url: urlVal,
+		},
+		{
+			desc: "hash with surrounding whitespace is trimmed",
+			records: []senml.Record{
+				{Name: "url", StringValue: &urlVal},
+				{Name: "hash", StringValue: func() *string { s := "  " + hashVal + "  "; return &s }()},
+			},
+			url:       urlVal,
+			sha256hex: hashVal,
 		},
 	}
 
@@ -577,6 +609,9 @@ func TestRun(t *testing.T) {
 			if len(tc.wantStates) > 0 {
 				assert.Equal(t, tc.wantStates, states, fmt.Sprintf("%s: unexpected state sequence", tc.desc))
 			}
+			// The library must not emit StateAborted; the service layer is the
+			// sole publisher of the aborted state (with the error message).
+			assert.NotContains(t, states, StateAborted, fmt.Sprintf("%s: library must not publish StateAborted", tc.desc))
 			if tc.checkCleanup {
 				entries, _ := os.ReadDir(dir)
 				for _, e := range entries {
@@ -587,4 +622,44 @@ func TestRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunReportsFileSizeAfterDownload(t *testing.T) {
+	content := []byte("fake binary content for size check")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".sha256") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+		_, _ = w.Write(content)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cfg := Config{BinaryPath: filepath.Join(dir, "agent"), DownloadDir: dir}
+
+	type stateInfo struct {
+		state        State
+		bytesWritten int64
+		totalBytes   int64
+	}
+	var infos []stateInfo
+	_ = Run(context.Background(), cfg, srv.URL+"/agent.bin", "deadbeef", 0,
+		func(s State, bw, tb int64, _ float64) {
+			infos = append(infos, stateInfo{s, bw, tb})
+		})
+
+	// After download, bytes/total in StateVerifying should match the file size
+	// so that subscribers see consistent values across HTTP- and MQTT-delivered updates.
+	var verifyInfo *stateInfo
+	for i := range infos {
+		if infos[i].state == StateVerifying {
+			verifyInfo = &infos[i]
+			break
+		}
+	}
+	require.NotNil(t, verifyInfo, "expected StateVerifying to be reported")
+	assert.Equal(t, int64(len(content)), verifyInfo.bytesWritten, "bytes should match file size in StateVerifying")
+	assert.Equal(t, int64(len(content)), verifyInfo.totalBytes, "total should match file size in StateVerifying")
 }

--- a/pkg/ota/ota_test.go
+++ b/pkg/ota/ota_test.go
@@ -40,11 +40,11 @@ func TestParseCfgFromRecords(t *testing.T) {
 	sizeVal := 153600.0
 
 	cases := []struct {
-		desc      string
-		records   []senml.Record
-		wantURL   string
-		wantHash  string
-		wantSize  uint64
+		desc     string
+		records  []senml.Record
+		wantURL  string
+		wantHash string
+		wantSize uint64
 	}{
 		{
 			desc:     "url, hash, and size present",
@@ -64,9 +64,9 @@ func TestParseCfgFromRecords(t *testing.T) {
 			records: []senml.Record{},
 		},
 		{
-			desc:     "url with nil string value is ignored",
-			records:  []senml.Record{{Name: "url", StringValue: nil}},
-			wantURL:  "",
+			desc:    "url with nil string value is ignored",
+			records: []senml.Record{{Name: "url", StringValue: nil}},
+			wantURL: "",
 		},
 	}
 

--- a/pkg/ota/ota_test.go
+++ b/pkg/ota/ota_test.go
@@ -34,6 +34,101 @@ func writeTempFile(t *testing.T, content []byte) string {
 	return f.Name()
 }
 
+func TestParseCfgFromRecords(t *testing.T) {
+	urlVal := "https://example.com/agent.bin"
+	hashVal := "abcdef1234567890"
+	sizeVal := 153600.0
+
+	cases := []struct {
+		desc      string
+		records   []senml.Record
+		wantURL   string
+		wantHash  string
+		wantSize  uint64
+	}{
+		{
+			desc:     "url, hash, and size present",
+			records:  []senml.Record{{Name: "url", StringValue: &urlVal}, {Name: "hash", StringValue: &hashVal}, {Name: "size", Value: &sizeVal}},
+			wantURL:  urlVal,
+			wantHash: hashVal,
+			wantSize: 153600,
+		},
+		{
+			desc:     "hash and size only (no url for MQTT path)",
+			records:  []senml.Record{{Name: "hash", StringValue: &hashVal}, {Name: "size", Value: &sizeVal}},
+			wantHash: hashVal,
+			wantSize: 153600,
+		},
+		{
+			desc:    "empty records",
+			records: []senml.Record{},
+		},
+		{
+			desc:     "url with nil string value is ignored",
+			records:  []senml.Record{{Name: "url", StringValue: nil}},
+			wantURL:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tr := ParseCfgFromRecords(tc.records)
+			assert.Equal(t, tc.wantURL, tr.URL)
+			assert.Equal(t, tc.wantHash, tr.SHA256Hex)
+			assert.Equal(t, tc.wantSize, tr.Size)
+		})
+	}
+}
+
+func TestRunFromData(t *testing.T) {
+	content := []byte("fake binary content for mqtt ota")
+
+	cases := []struct {
+		desc            string
+		data            []byte
+		sha256hex       string
+		wantErrContains string
+	}{
+		{
+			desc:            "empty hash rejected",
+			data:            content,
+			sha256hex:       "",
+			wantErrContains: "hash required",
+		},
+		{
+			desc:            "hash mismatch",
+			data:            content,
+			sha256hex:       "deadbeef",
+			wantErrContains: "sha256 mismatch",
+		},
+		{
+			desc:      "correct hash proceeds to exec (expected to fail in test)",
+			data:      content,
+			sha256hex: sha256hex(content),
+			// syscall.Exec fails because content is not a valid binary;
+			// we just check there is an error (not a verify error).
+			wantErrContains: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			dir := t.TempDir()
+			dst := filepath.Join(dir, "agent-dst")
+			cfg := Config{BinaryPath: dst, DownloadDir: dir}
+
+			var states []State
+			err := RunFromData(context.Background(), cfg, tc.data, tc.sha256hex,
+				func(s State, _, _ int64, _ float64) { states = append(states, s) })
+
+			assert.Error(t, err)
+			if tc.wantErrContains != "" {
+				assert.ErrorContains(t, err, tc.wantErrContains)
+			}
+		})
+	}
+}
+
 func TestState_String(t *testing.T) {
 	cases := []struct {
 		state    State
@@ -227,7 +322,7 @@ func TestDownload(t *testing.T) {
 			}
 
 			var progress []float64
-			path, err := download(ctx, url, t.TempDir(), tc.sizeLimit, func(pct float64) {
+			path, err := download(ctx, url, t.TempDir(), tc.sizeLimit, func(_, _ int64, pct float64) {
 				progress = append(progress, pct)
 			})
 			if tc.wantErr {
@@ -258,7 +353,7 @@ func TestDownload(t *testing.T) {
 		defer srv.Close()
 
 		var calls []float64
-		path, err := download(context.Background(), srv.URL, t.TempDir(), 0, func(pct float64) {
+		path, err := download(context.Background(), srv.URL, t.TempDir(), 0, func(_, _ int64, pct float64) {
 			calls = append(calls, pct)
 		})
 		require.NoError(t, err)
@@ -473,7 +568,7 @@ func TestRun(t *testing.T) {
 			dir := t.TempDir()
 			cfg := Config{BinaryPath: filepath.Join(dir, "agent"), DownloadDir: dir}
 			var states []State
-			err := Run(context.Background(), cfg, url, tc.sha256hex, 0, func(s State, _ float64) {
+			err := Run(context.Background(), cfg, url, tc.sha256hex, 0, func(s State, _, _ int64, _ float64) {
 				states = append(states, s)
 			})
 

--- a/service.go
+++ b/service.go
@@ -221,6 +221,10 @@ type Service interface {
 	// OTA triggers an over-the-air binary update by downloading from url.
 	OTA(ctx context.Context, url, sha256hex string, size uint64) error
 
+	// OTAFromData installs firmware from a binary payload received via MQTT.
+	// sha256hex must be the hex-encoded SHA-256 of data.
+	OTAFromData(ctx context.Context, data []byte, sha256hex string) error
+
 	// Reset performs a reset in the given mode. Supported modes are:
 	//   - "graceful"  – clean shutdown, save state, close connections, then exec
 	//   - "immediate" – emergency reset with minimal cleanup, then exec
@@ -1320,20 +1324,30 @@ func (a *agent) OTA(ctx context.Context, url, sha256hex string, size uint64) err
 	qos := cfg.MQTT.QoS
 	statusTopic := fmt.Sprintf("m/%s/c/%s/ota/status", domainID, ctrlChan)
 
-	progressFn := func(state ota.State, progress float64) {
+	publishStatus := func(state ota.State, bytesWritten, totalBytes int64, progress float64, errMsg string) {
 		now := float64(time.Now().UnixNano()) / float64(time.Second)
 		stateStr := strings.ToLower(state.String())
-		statusPack := []senml.Record{
-			{BaseName: "gw:", BaseTime: now, Name: "ota_state", StringValue: &stateStr},
-			{Name: "ota_progress", Unit: "%", Value: &progress},
+		bytesVal := float64(bytesWritten)
+		totalVal := float64(totalBytes)
+		pack := []senml.Record{
+			{BaseName: "gw:", BaseTime: now, Name: "state", StringValue: &stateStr},
+			{Name: "bytes", Unit: "By", Value: &bytesVal},
+			{Name: "total", Unit: "By", Value: &totalVal},
+			{Name: "progress", Unit: "%", Value: &progress},
 		}
-		b, err := senml.EncodeRecords(statusPack)
+		if errMsg != "" {
+			pack = append(pack, senml.Record{Name: "error", StringValue: &errMsg})
+		}
+		b, err := senml.EncodeRecords(pack)
 		if err != nil {
 			a.logger.Warn("Failed to encode OTA status", slog.Any("error", err))
 			return
 		}
-		token := a.mqttClient.Publish(statusTopic, qos, false, b)
+		token := a.mqttClient.Publish(statusTopic, qos, true, b)
 		token.Wait()
+	}
+	progressFn := func(state ota.State, bytesWritten, totalBytes int64, progress float64) {
+		publishStatus(state, bytesWritten, totalBytes, progress, "")
 	}
 
 	runErr := ota.Run(otaCtx, otaCfg, url, sha256hex, size, progressFn)
@@ -1343,9 +1357,88 @@ func (a *agent) OTA(ctx context.Context, url, sha256hex string, size uint64) err
 			a.otaLastErr = "aborted"
 		}
 		if a.otaAborted.Load() {
-			progressFn(ota.StateAborted, 0)
+			publishStatus(ota.StateAborted, 0, 0, 0, "OTA aborted by user")
 			a.otaLastErr = "OTA aborted by user"
 		} else {
+			publishStatus(ota.StateAborted, 0, 0, 0, runErr.Error())
+			a.otaLastErr = runErr.Error()
+		}
+		a.otaMu.Unlock()
+	}
+	return runErr
+}
+
+func (a *agent) OTAFromData(ctx context.Context, data []byte, sha256hex string) error {
+	cfg := a.Config()
+	if !cfg.OTA.Enabled {
+		return errors.New("OTA is disabled")
+	}
+
+	otaCtx, otaCancel := context.WithCancel(ctx)
+
+	a.otaMu.Lock()
+	if a.otaBusy.Load() {
+		a.otaMu.Unlock()
+		otaCancel()
+		return errors.New("OTA already in progress")
+	}
+	a.otaBusy.Store(true)
+	a.otaLastErr = ""
+	a.otaCancel = otaCancel
+	a.otaAborted.Store(false)
+	a.otaMu.Unlock()
+
+	defer func() {
+		a.otaMu.Lock()
+		a.otaCancel = nil
+		a.otaMu.Unlock()
+		a.otaBusy.Store(false)
+	}()
+
+	otaCfg := ota.Config{
+		BinaryPath:  cfg.OTA.BinaryPath,
+		DownloadDir: cfg.OTA.DownloadDir,
+	}
+
+	domainID := cfg.DomainID
+	ctrlChan := cfg.Channels.CtrlChan()
+	qos := cfg.MQTT.QoS
+	statusTopic := fmt.Sprintf("m/%s/c/%s/ota/status", domainID, ctrlChan)
+
+	publishStatus := func(state ota.State, bytesWritten, totalBytes int64, progress float64, errMsg string) {
+		now := float64(time.Now().UnixNano()) / float64(time.Second)
+		stateStr := strings.ToLower(state.String())
+		bytesVal := float64(bytesWritten)
+		totalVal := float64(totalBytes)
+		pack := []senml.Record{
+			{BaseName: "gw:", BaseTime: now, Name: "state", StringValue: &stateStr},
+			{Name: "bytes", Unit: "By", Value: &bytesVal},
+			{Name: "total", Unit: "By", Value: &totalVal},
+			{Name: "progress", Unit: "%", Value: &progress},
+		}
+		if errMsg != "" {
+			pack = append(pack, senml.Record{Name: "error", StringValue: &errMsg})
+		}
+		b, err := senml.EncodeRecords(pack)
+		if err != nil {
+			a.logger.Warn("Failed to encode OTA status", slog.Any("error", err))
+			return
+		}
+		token := a.mqttClient.Publish(statusTopic, qos, true, b)
+		token.Wait()
+	}
+	progressFn := func(state ota.State, bytesWritten, totalBytes int64, progress float64) {
+		publishStatus(state, bytesWritten, totalBytes, progress, "")
+	}
+
+	runErr := ota.RunFromData(otaCtx, otaCfg, data, sha256hex, progressFn)
+	if runErr != nil {
+		a.otaMu.Lock()
+		if a.otaAborted.Load() {
+			publishStatus(ota.StateAborted, 0, 0, 0, "OTA aborted by user")
+			a.otaLastErr = "OTA aborted by user"
+		} else {
+			publishStatus(ota.StateAborted, 0, 0, 0, runErr.Error())
 			a.otaLastErr = runErr.Error()
 		}
 		a.otaMu.Unlock()

--- a/service.go
+++ b/service.go
@@ -82,6 +82,9 @@ const (
 	senmlNameUptime = "uptime"
 	notAllowed      = "not_allowed"
 
+	// senmlBaseGateway is the SenML base name used for gateway-scoped records.
+	senmlBaseGateway = "gw:"
+
 	provisionTimeout = 30 * time.Second
 )
 
@@ -1213,7 +1216,7 @@ func (a *agent) gatewayTelemetryPayload() []senml.Record {
 	uptime := time.Since(startTime).Seconds()
 
 	records := []senml.Record{
-		{BaseName: "gw:", BaseTime: now, Name: "uptime", Unit: "s", Value: &uptime},
+		{BaseName: senmlBaseGateway, BaseTime: now, Name: "uptime", Unit: "s", Value: &uptime},
 	}
 
 	if total, _, available, ok := readMemoryStats(); ok {
@@ -1325,26 +1328,7 @@ func (a *agent) OTA(ctx context.Context, url, sha256hex string, size uint64) err
 	statusTopic := fmt.Sprintf("m/%s/c/%s/ota/status", domainID, ctrlChan)
 
 	publishStatus := func(state ota.State, bytesWritten, totalBytes int64, progress float64, errMsg string) {
-		now := float64(time.Now().UnixNano()) / float64(time.Second)
-		stateStr := strings.ToLower(state.String())
-		bytesVal := float64(bytesWritten)
-		totalVal := float64(totalBytes)
-		pack := []senml.Record{
-			{BaseName: "gw:", BaseTime: now, Name: "state", StringValue: &stateStr},
-			{Name: "bytes", Unit: "By", Value: &bytesVal},
-			{Name: "total", Unit: "By", Value: &totalVal},
-			{Name: "progress", Unit: "%", Value: &progress},
-		}
-		if errMsg != "" {
-			pack = append(pack, senml.Record{Name: "error", StringValue: &errMsg})
-		}
-		b, err := senml.EncodeRecords(pack)
-		if err != nil {
-			a.logger.Warn("Failed to encode OTA status", slog.Any("error", err))
-			return
-		}
-		token := a.mqttClient.Publish(statusTopic, qos, true, b)
-		token.Wait()
+		a.publishOTAStatus(statusTopic, qos, state, bytesWritten, totalBytes, progress, errMsg)
 	}
 	progressFn := func(state ota.State, bytesWritten, totalBytes int64, progress float64) {
 		publishStatus(state, bytesWritten, totalBytes, progress, "")
@@ -1406,26 +1390,7 @@ func (a *agent) OTAFromData(ctx context.Context, data []byte, sha256hex string) 
 	statusTopic := fmt.Sprintf("m/%s/c/%s/ota/status", domainID, ctrlChan)
 
 	publishStatus := func(state ota.State, bytesWritten, totalBytes int64, progress float64, errMsg string) {
-		now := float64(time.Now().UnixNano()) / float64(time.Second)
-		stateStr := strings.ToLower(state.String())
-		bytesVal := float64(bytesWritten)
-		totalVal := float64(totalBytes)
-		pack := []senml.Record{
-			{BaseName: "gw:", BaseTime: now, Name: "state", StringValue: &stateStr},
-			{Name: "bytes", Unit: "By", Value: &bytesVal},
-			{Name: "total", Unit: "By", Value: &totalVal},
-			{Name: "progress", Unit: "%", Value: &progress},
-		}
-		if errMsg != "" {
-			pack = append(pack, senml.Record{Name: "error", StringValue: &errMsg})
-		}
-		b, err := senml.EncodeRecords(pack)
-		if err != nil {
-			a.logger.Warn("Failed to encode OTA status", slog.Any("error", err))
-			return
-		}
-		token := a.mqttClient.Publish(statusTopic, qos, true, b)
-		token.Wait()
+		a.publishOTAStatus(statusTopic, qos, state, bytesWritten, totalBytes, progress, errMsg)
 	}
 	progressFn := func(state ota.State, bytesWritten, totalBytes int64, progress float64) {
 		publishStatus(state, bytesWritten, totalBytes, progress, "")
@@ -1444,6 +1409,31 @@ func (a *agent) OTAFromData(ctx context.Context, data []byte, sha256hex string) 
 		a.otaMu.Unlock()
 	}
 	return runErr
+}
+
+// publishOTAStatus publishes a retained OTA status SenML record to statusTopic.
+// errMsg is appended as an "error" field only when non-empty.
+func (a *agent) publishOTAStatus(statusTopic string, qos byte, state ota.State, bytesWritten, totalBytes int64, progress float64, errMsg string) {
+	now := float64(time.Now().UnixNano()) / float64(time.Second)
+	stateStr := strings.ToLower(state.String())
+	bytesVal := float64(bytesWritten)
+	totalVal := float64(totalBytes)
+	pack := []senml.Record{
+		{BaseName: senmlBaseGateway, BaseTime: now, Name: "state", StringValue: &stateStr},
+		{Name: "bytes", Unit: "By", Value: &bytesVal},
+		{Name: "total", Unit: "By", Value: &totalVal},
+		{Name: "progress", Unit: "%", Value: &progress},
+	}
+	if errMsg != "" {
+		pack = append(pack, senml.Record{Name: "error", StringValue: &errMsg})
+	}
+	b, err := senml.EncodeRecords(pack)
+	if err != nil {
+		a.logger.Warn("Failed to encode OTA status", slog.Any("error", err))
+		return
+	}
+	token := a.mqttClient.Publish(statusTopic, qos, true, b)
+	token.Wait()
 }
 
 func (a *agent) OTAAbort() error {

--- a/service_test.go
+++ b/service_test.go
@@ -1791,13 +1791,26 @@ func TestOTAStatusPublishesErrorOnFailure(t *testing.T) {
 
 	require.NotEmpty(t, publishedPayloads, "expected OTA status messages on failure")
 
-	// Final message should include the 'error' field.
-	last := publishedPayloads[len(publishedPayloads)-1]
-	var records []senml.Record
-	require.NoError(t, json.Unmarshal(last, &records))
+	// Count how many StateAborted messages were published — there must be
+	// exactly one (from the service layer, with the error field). The library
+	// no longer emits StateAborted, so a double publish would be a regression.
+	abortedCount := 0
+	var lastRecords []senml.Record
+	for _, payload := range publishedPayloads {
+		var records []senml.Record
+		require.NoError(t, json.Unmarshal(payload, &records))
+		lastRecords = records
+		for _, r := range records {
+			if r.Name == "state" && r.StringValue != nil && *r.StringValue == "aborted" {
+				abortedCount++
+			}
+		}
+	}
+	assert.Equal(t, 1, abortedCount, "exactly one StateAborted status should be published")
 
+	// Final message should include the 'error' field.
 	hasError := false
-	for _, r := range records {
+	for _, r := range lastRecords {
 		if r.Name == "error" {
 			hasError = true
 			break

--- a/service_test.go
+++ b/service_test.go
@@ -5,6 +5,7 @@ package agent_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -1694,6 +1695,166 @@ func sdkProvisionServer(t *testing.T, deviceID, deviceKey, channelID string) *ht
 	}))
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func TestOTAStatusPublishing(t *testing.T) {
+	content := []byte("fake agent binary content for ota test")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return 404 for the sha256 sidecar so verify fails cleanly without exec.
+		if strings.HasSuffix(r.URL.Path, ".sha256") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+		_, _ = w.Write(content)
+	}))
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.OTA = agent.OTAConfig{
+		Enabled:     true,
+		BinaryPath:  filepath.Join(t.TempDir(), "agent"),
+		DownloadDir: t.TempDir(),
+	}
+
+	svc, mqttClient, _, err := newService(t, cfg, nil)
+	require.NoError(t, err)
+
+	statusTopic := mqttTopic("ctrl-channel", "ota/status")
+
+	var publishedPayloads [][]byte
+	token := agentmocks.NewMQTTToken(t)
+	token.On("Wait").Return(true).Maybe()
+	mqttClient.On("Publish", statusTopic, cfg.MQTT.QoS, true, mock.Anything).
+		Run(func(args mock.Arguments) {
+			if p, ok := args[3].([]byte); ok {
+				publishedPayloads = append(publishedPayloads, p)
+			}
+		}).
+		Return(token).
+		Maybe()
+
+	// OTA will fail at verify (no sha256 provided and sidecar returns 404).
+	// The important thing is that status messages were published along the way.
+	_ = svc.OTA(context.Background(), srv.URL+"/agent.bin", "", 0)
+
+	require.NotEmpty(t, publishedPayloads, "expected OTA status messages to be published")
+
+	// Decode the first status message and verify it has the correct SenML fields.
+	first := publishedPayloads[0]
+	var records []senml.Record
+	require.NoError(t, json.Unmarshal(first, &records), "OTA status must be valid JSON")
+
+	fieldNames := map[string]bool{}
+	for _, r := range records {
+		fieldNames[r.Name] = true
+	}
+	assert.True(t, fieldNames["state"], "status must include 'state' field")
+	assert.True(t, fieldNames["bytes"], "status must include 'bytes' field")
+	assert.True(t, fieldNames["total"], "status must include 'total' field")
+	assert.True(t, fieldNames["progress"], "status must include 'progress' field")
+}
+
+func TestOTAStatusPublishesErrorOnFailure(t *testing.T) {
+	// Use an unreachable URL so download fails immediately.
+	closedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	closedSrv.Close()
+
+	cfg := testConfig()
+	cfg.OTA = agent.OTAConfig{
+		Enabled:     true,
+		BinaryPath:  filepath.Join(t.TempDir(), "agent"),
+		DownloadDir: t.TempDir(),
+	}
+
+	svc, mqttClient, _, err := newService(t, cfg, nil)
+	require.NoError(t, err)
+
+	statusTopic := mqttTopic("ctrl-channel", "ota/status")
+
+	var publishedPayloads [][]byte
+	token := agentmocks.NewMQTTToken(t)
+	token.On("Wait").Return(true).Maybe()
+	mqttClient.On("Publish", statusTopic, cfg.MQTT.QoS, true, mock.Anything).
+		Run(func(args mock.Arguments) {
+			if p, ok := args[3].([]byte); ok {
+				publishedPayloads = append(publishedPayloads, p)
+			}
+		}).
+		Return(token).
+		Maybe()
+
+	otaErr := svc.OTA(context.Background(), closedSrv.URL, "", 0)
+	assert.Error(t, otaErr)
+
+	require.NotEmpty(t, publishedPayloads, "expected OTA status messages on failure")
+
+	// Final message should include the 'error' field.
+	last := publishedPayloads[len(publishedPayloads)-1]
+	var records []senml.Record
+	require.NoError(t, json.Unmarshal(last, &records))
+
+	hasError := false
+	for _, r := range records {
+		if r.Name == "error" {
+			hasError = true
+			break
+		}
+	}
+	assert.True(t, hasError, "final OTA status on failure must include 'error' field")
+}
+
+func TestOTAFromDataStatusPublishing(t *testing.T) {
+	content := []byte("fake agent binary content for mqtt ota test")
+
+	// Compute SHA-256 so RunFromData can verify.
+	h := sha256.New()
+	h.Write(content)
+	hash := fmt.Sprintf("%x", h.Sum(nil))
+
+	cfg := testConfig()
+	cfg.OTA = agent.OTAConfig{
+		Enabled:     true,
+		BinaryPath:  filepath.Join(t.TempDir(), "agent"),
+		DownloadDir: t.TempDir(),
+	}
+
+	svc, mqttClient, _, err := newService(t, cfg, nil)
+	require.NoError(t, err)
+
+	statusTopic := mqttTopic("ctrl-channel", "ota/status")
+
+	var publishedPayloads [][]byte
+	token := agentmocks.NewMQTTToken(t)
+	token.On("Wait").Return(true).Maybe()
+	mqttClient.On("Publish", statusTopic, cfg.MQTT.QoS, true, mock.Anything).
+		Run(func(args mock.Arguments) {
+			if p, ok := args[3].([]byte); ok {
+				publishedPayloads = append(publishedPayloads, p)
+			}
+		}).
+		Return(token).
+		Maybe()
+
+	// OTAFromData will fail at syscall.Exec in test; the important thing is
+	// that status messages were published.
+	_ = svc.OTAFromData(context.Background(), content, hash)
+
+	require.NotEmpty(t, publishedPayloads, "expected OTA from-data status messages")
+	last := publishedPayloads[len(publishedPayloads)-1]
+	var records []senml.Record
+	require.NoError(t, json.Unmarshal(last, &records))
+
+	fieldNames := map[string]bool{}
+	for _, r := range records {
+		fieldNames[r.Name] = true
+	}
+	assert.True(t, fieldNames["state"], "status must include 'state' field")
+	assert.True(t, fieldNames["bytes"], "status must include 'bytes' field")
+	assert.True(t, fieldNames["total"], "status must include 'total' field")
+	assert.True(t, fieldNames["progress"], "status must include 'progress' field")
 }
 
 func TestDeviceManager(t *testing.T) {


### PR DESCRIPTION
### What does this do?

Implements OTA status publishing to MQTT as described in #79. The agent now reports download progress, verification status, and update state in real-time over MQTT, and supports receiving firmware binaries directly via MQTT as an alternative to HTTP download.

**Status topic publishing (`m/{domain}/c/{ctrl_channel}/ota/status`)**
- Publishes on every state transition: `triggered → downloading → verifying → ready → restarting` (or `aborted` on failure)
- Reports download progress every 5% with `bytes`, `total`, and `progress` fields
- Uses `retain=true` so the broker always holds the last known OTA state
- Includes an `error` field in the final status message on failure or abort
- SenML fields match the spec: `state` (string), `bytes` (By), `total` (By), `progress` (%)

**MQTT binary delivery (`m/{domain}/c/{ctrl_channel}/ota`)**
- New `ota/cfg` flow: when `url` is absent but `hash` and `size` are present, the broker primes a pending data receiver
- Firmware binary arrives as a raw MQTT payload on the `ota` topic
- Agent verifies the SHA-256 hash and installs — same verify/replace path as HTTP download
- HTTP download path is unchanged

**API / internals**
- `ProgressFn` extended to include `bytesWritten, totalBytes int64` alongside `progress float64`
- New `ParseCfgFromRecords()` in `pkg/ota` — parses cfg records without requiring a URL
- New `RunFromData()` in `pkg/ota` — installs firmware from an in-memory byte slice
- New `OTAFromData(ctx, data, sha256hex)` method on `Service` interface (+ logging/metrics middleware)

### Which issue(s) does this PR fix/relate to?

Resolves #79

### List any changes that modify/break current functionality

- `ota.ProgressFn` signature changed: `func(State, float64)` → `func(State, int64, int64, float64)`. Any external code calling `ota.Run()` with a progress callback must update the callback signature.
- OTA status SenML field names changed: `ota_state` → `state`, `ota_progress` → `progress`. New fields `bytes` and `total` are added.
- OTA status messages now use `retain=true` (previously `false`).

### Have you included tests for your changes?

Yes:
- Updated all existing `ota_test.go` tests for the new `ProgressFn` signature
- `TestParseCfgFromRecords` — covers the new URL-optional cfg parser
- `TestRunFromData` — covers MQTT binary delivery path (empty hash, hash mismatch, valid hash)
- `TestOTAStatusPublishing` — verifies correct SenML fields on the status topic
- `TestOTAStatusPublishesErrorOnFailure` — verifies `error` field is included in the final failure status
- `TestOTAFromDataStatusPublishing` — verifies status publishing for the MQTT data-delivery path

### Did you document any new/modified functionality?

The `ota/cfg` and `ota` topic behaviour is described in the inline code comments and follows the protocol defined in #79.

### Notes

`syscall.Exec` is called on a successful OTA install (process is replaced in-place). Tests that exercise the full verify+replace path intentionally use invalid binary content so `syscall.Exec` returns `ENOEXEC` rather than replacing the test process.